### PR TITLE
Fix CommandBus.Stop panicking in-flight Dispatch calls

### DIFF
--- a/command_bus.go
+++ b/command_bus.go
@@ -42,6 +42,7 @@ type CommandBus struct {
 	handlers    map[string]CommandHandler[Command]
 	queues      []chan queuedCommand
 	stopCh      chan struct{}
+	stopOnce    sync.Once
 	wg          sync.WaitGroup
 	mu          sync.Mutex
 	shardCount  int
@@ -82,30 +83,34 @@ func NewCommandBus(bufferSize int, shardCount int) *CommandBus {
 	return bus
 }
 
-// Dispatch enqueues a command for processing by the registered handler and
-// waits for the result. It is safe to call concurrently.
+// Dispatch enqueues cmd for the handler registered for its type and blocks
+// until that handler returns. Commands for the same aggregate are routed to the
+// same shard, and each shard is drained by a single worker, so they are never
+// handled concurrently. Dispatch itself is safe to call concurrently.
 //
-// Parameters:
-//   - ctx: the context for cancellation or timeout
-//   - cmd: the command to dispatch
-//
-// Returns:
-//   - AppendResult: indicates success/failure of command processing
-//   - error: non-nil if the dispatch failed due to context cancellation or processing error
-//
-// Notes:
-//   - Returns an error immediately if the bus has been stopped.
-//   - Waits for the handler to complete and sends the result back via a response channel.
+// The returned [AppendResult] carries the outcome of the append. The error is
+// non-nil if ctx is cancelled before the command is enqueued or before the
+// result arrives, if no handler is registered for the command's type, if the
+// handler returns an error or panics, or if the bus has been stopped. Once the
+// bus is stopped the error wraps [ErrCommandBusClosed], including for a call
+// already parked waiting to enqueue.
 func (b *CommandBus) Dispatch(ctx context.Context, cmd Command) (AppendResult, error) {
+	// Registering as in-flight must be atomic with the stopCh check: sync.WaitGroup
+	// forbids an Add that races a Wait, and Stop calls Wait as soon as it has closed
+	// stopCh. Holding b.mu across both makes every Add happen-before that close, so
+	// Stop is a real barrier and go test -race stays clean.
+	b.mu.Lock()
 	select {
 	case <-b.stopCh:
+		b.mu.Unlock()
 		return AppendResult{Successful: false}, fmt.Errorf("dispatch command %T for aggregate %q: %w", cmd, cmd.AggregateID(), ErrCommandBusClosed)
 	default:
 	}
+	b.wg.Add(1)
+	b.mu.Unlock()
+	defer b.wg.Done()
 
 	responseCh := make(chan commandResult, 1)
-	b.wg.Add(1)
-	defer b.wg.Done()
 
 	shard := b.selectShard(cmd.AggregateID())
 
@@ -113,6 +118,8 @@ func (b *CommandBus) Dispatch(ctx context.Context, cmd Command) (AppendResult, e
 	select {
 	case b.queues[shard] <- queuedCommand{Ctx: ctx, Command: cmd, ResponseCh: responseCh}:
 		// Wait for processing result
+	case <-b.stopCh:
+		return AppendResult{Successful: false}, fmt.Errorf("dispatch command %T for aggregate %q: %w", cmd, cmd.AggregateID(), ErrCommandBusClosed)
 	case <-ctx.Done():
 		return AppendResult{Successful: false}, fmt.Errorf("dispatch command %T for aggregate %q: %w", cmd, cmd.AggregateID(), ctx.Err()) // Context timeout before enqueueing
 	}
@@ -130,7 +137,21 @@ func (b *CommandBus) Dispatch(ctx context.Context, cmd Command) (AppendResult, e
 
 // worker processes commands from a single shard queues.
 func (b *CommandBus) worker(queue chan queuedCommand) {
-	for cmd := range queue {
+
+	for {
+		var cmd queuedCommand
+
+		select {
+		case cmd = <-queue:
+		case <-b.stopCh:
+			// drain whatever is still queued, then exit
+			select {
+			case cmd = <-queue:
+			default:
+				return
+			}
+		}
+
 		cmdName := fmt.Sprintf("%T", cmd.Command)
 
 		h, exists := b.handlers[cmdName]
@@ -221,20 +242,20 @@ func Register[C Command](b *CommandBus, handler CommandHandler[C]) {
 	b.handlers[cmdName] = h
 }
 
-// Stop shuts down the CommandBus safely.
+// Stop shuts down the bus. It stops accepting new commands, lets the workers
+// finish whatever is already queued, and waits for every in-flight [CommandBus.Dispatch]
+// to return before it does.
 //
-// Behavior:
-//   - Stops accepting new commands.
-//   - Closes the internal queues channel.
-//   - Waits for all in-flight commands to finish before returning.
-//
-// Example:
-//
-//	bus.Stop()
+// A Dispatch racing Stop either completes normally or fails with an error
+// wrapping [ErrCommandBusClosed]; it never panics. Stop is idempotent and safe
+// to call concurrently, but the bus cannot be restarted afterwards.
 func (b *CommandBus) Stop() {
-	close(b.stopCh)
-	for _, q := range b.queues {
-		close(q)
-	}
+	// Close under b.mu so it cannot land between Dispatch's stopCh check and its
+	// wg.Add. Once this returns, every subsequent Dispatch observes stopCh closed
+	// and bails out without touching wg, so Wait sees a final count.
+	b.mu.Lock()
+	b.stopOnce.Do(func() { close(b.stopCh) })
+	b.mu.Unlock()
+
 	b.wg.Wait()
 }

--- a/command_bus_test.go
+++ b/command_bus_test.go
@@ -3,6 +3,8 @@ package eventsourcing
 import (
 	"context"
 	"errors"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
@@ -194,3 +196,115 @@ func TestNewCommandBus(t *testing.T) {
 		})
 	}
 }
+
+type stopProbeCmd struct{ ID string }
+
+func (c stopProbeCmd) AggregateID() string { return c.ID }
+
+// TestCommandBus_StopDoesNotPanicPendingDispatch asserts that a Dispatch parked
+// on the queue send when Stop runs is either processed or fails with
+// ErrCommandBusClosed. It must never panic the sender, which is what closing the
+// shard queues used to do.
+func TestCommandBus_StopDoesNotPanicPendingDispatch(t *testing.T) {
+	// Unbuffered queue, single shard: every Dispatch beyond the one the worker
+	// picked up parks on the channel send.
+	bus := NewCommandBus(0, 1)
+
+	release := make(chan struct{})
+	var once sync.Once
+	Register(bus, func(ctx context.Context, cmd stopProbeCmd) (AppendResult, error) {
+		<-release // occupy the single worker
+		return AppendResult{Successful: true}, nil
+	})
+
+	const dispatchers = 32
+	var wg sync.WaitGroup
+	errCh := make(chan error, dispatchers)
+
+	for i := 0; i < dispatchers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := bus.Dispatch(context.Background(), stopProbeCmd{ID: "agg-1"})
+			errCh <- err
+		}()
+	}
+
+	// Give the dispatchers time to block on the queue send.
+	time.Sleep(100 * time.Millisecond)
+
+	go func() {
+		// Let Stop's wg.Wait() finish once it gets there.
+		time.Sleep(200 * time.Millisecond)
+		once.Do(func() { close(release) })
+	}()
+
+	bus.Stop() // must not panic the senders parked on the queue
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil && !errors.Is(err, ErrCommandBusClosed) {
+			t.Fatalf("unexpected dispatch error: %v", err)
+		}
+	}
+}
+
+// TestCommandBus_StopIsIdempotent guards the sync.Once around close(stopCh); a
+// second Stop used to panic with "close of closed channel".
+func TestCommandBus_StopIsIdempotent(t *testing.T) {
+	bus := NewCommandBus(10, 1)
+
+	Register(bus, func(ctx context.Context, cmd testCmd) (AppendResult, error) {
+		return AppendResult{Successful: true}, nil
+	})
+
+	bus.Stop()
+	bus.Stop() // must not panic
+}
+
+type benchCmd struct{ ID string }
+
+func (c benchCmd) AggregateID() string { return c.ID }
+
+// benchmarkDispatch measures end-to-end Dispatch throughput. Dispatch is
+// synchronous, so this covers the whole round trip: the stopCh check and wg.Add
+// under b.mu, the queue send, worker pickup, the handler, and the response
+// receive.
+func benchmarkDispatch(b *testing.B, shards, parallelism int) {
+	bus := NewCommandBus(1024, shards)
+	defer bus.Stop()
+
+	Register(bus, func(ctx context.Context, cmd benchCmd) (AppendResult, error) {
+		return AppendResult{Successful: true}, nil
+	})
+
+	ids := make([]string, 512)
+	for i := range ids {
+		ids[i] = "agg-" + strconv.Itoa(i)
+	}
+
+	ctx := context.Background()
+	if parallelism > 0 {
+		b.SetParallelism(parallelism)
+	}
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		i := 0
+		for pb.Next() {
+			if _, err := bus.Dispatch(ctx, benchCmd{ID: ids[i%len(ids)]}); err != nil {
+				b.Fatal(err)
+			}
+			i++
+		}
+	})
+}
+
+func BenchmarkCommandBusDispatchShards1(b *testing.B)  { benchmarkDispatch(b, 1, 0) }
+func BenchmarkCommandBusDispatchShards8(b *testing.B)  { benchmarkDispatch(b, 8, 0) }
+func BenchmarkCommandBusDispatchShards32(b *testing.B) { benchmarkDispatch(b, 32, 0) }
+
+// BenchmarkCommandBusDispatchContended oversubscribes GOMAXPROCS 32x so every
+// dispatcher contends for the b.mu that orders wg.Add against Stop's wg.Wait.
+func BenchmarkCommandBusDispatchContended(b *testing.B) { benchmarkDispatch(b, 16, 32) }


### PR DESCRIPTION
Fixes #20

## The bug

`Stop` closed the shard queues while concurrent `Dispatch` callers could be parked on a send to those same channels. Go panics *every* blocked sender when a channel is closed, so this crashed the process from inside library code the caller cannot recover from:

```
panic: send on closed channel
	command_bus.go:113
```

The window is not theoretical — it is open whenever the workers are busy and the queue is full, which is the normal state for any bus under load, because every additional `Dispatch` blocks on the send until a worker frees up.

Closing the queues was the wrong shutdown mechanism regardless: `worker` ranged over the queue, so the producers (`Dispatch`) and the closer (`Stop`) were different parties, which violates the "only the sender closes" rule.

## The fix

- **`Stop` no longer closes the queues.** Workers drain what is already queued and exit on `stopCh`.
- **`Dispatch`s enqueue `select` gains a `<-b.stopCh` case**, so a parked sender unblocks with `ErrCommandBusClosed` instead of panicking.
- **`close(stopCh)` is guarded by a `sync.Once`**, so a second `Stop` is a no-op rather than a `close of closed channel` panic.

## The `wg.Add` / `wg.Wait` race

Fixing the panic alone left a second, real defect. `Dispatch` called `wg.Add(1)` after checking `stopCh`, with no ordering against `Stop`s `wg.Wait()`:

```
T1 (Dispatch): select on stopCh -> still open, fall through
T2 (Stop):     close(stopCh)
T2 (Stop):     wg.Wait()  -> counter is 0, returns
T1 (Dispatch): wg.Add(1)  <- races Wait
```

`sync.WaitGroup` forbids an `Add` that races a `Wait`, and `go test -race` reports it. Reordering `Add` relative to the `stopCh` check does not help — observing the channel as *open* establishes no happens-before edge with `Stop`.

Beyond the race report it is a contract break: `Stop` could return while a straggler command was still in flight, despite promising it "waits for all in-flight commands to finish". That matters for the common teardown sequence:

```go
bus.Stop()      // returns, believing everything is drained
store.Close()   // straggler handler still running, now hits a closed store
```

`Dispatch` now holds `b.mu` across the `stopCh` check and the `wg.Add`, and `Stop` closes `stopCh` under the same lock before calling `Wait`. That makes every `Add` either happen-before the close or not happen at all.

### Throughput cost

Measured, not assumed — `BenchmarkCommandBusDispatch*` are included so the claim stays checkable:

| Benchmark | before | after | delta |
|---|---|---|---|
| shards=1 | 728.4 ns/op | 725.8 ns/op | −0.4% |
| shards=8 | 747.8 ns/op | 749.6 ns/op | +0.2% |
| shards=32 | 783.7 ns/op | 783.3 ns/op | −0.1% |
| contended, 512 goroutines | 627.1 ns/op | 638.0 ns/op | +1.7% |

Within run-to-run noise; several locked runs came out faster. `Dispatch` is synchronous and parks on the response channel, so almost no goroutines sit inside the ~20 ns critical section at any instant — throughput is bound by the worker round trip, not the mutex. `b.mu` is otherwise only taken by `Register`/`Use`, which are startup-only.

## Docs

`Stop`s comment claimed it "Closes the internal queues channel" — precisely the behaviour removed here. Rewrote the `Dispatch` and `Stop` comments as prose per [go.dev/doc/comment](https://go.dev/doc/comment); the `Parameters:`/`Returns:`/`Notes:` blocks were not godoc headings and rendered as stray one-line paragraphs.

## Verification

`TestCommandBus_StopDoesNotPanicPendingDispatch` (32 dispatchers parked on an unbuffered queue) and `TestCommandBus_StopIsIdempotent`, both in `command_bus_test.go`. Full suite green under `go test -race -count=5 ./...`.