### PR TITLE
Correct CommandBus.Use godoc: middleware is applied at Register time

### DIFF
--- a/middleware.go
+++ b/middleware.go
@@ -2,19 +2,15 @@ package eventsourcing
 
 import "context"
 
-// CommandHandlerMiddleware defines a function type for decorating command handlers on the CommandBus.
-// Registering one or more middlewares via Use() causes every command handler — regardless of
-// when it was registered — to be wrapped with the full middleware chain.
+// CommandHandlerMiddleware decorates a command handler on a [CommandBus] with a
+// cross-cutting concern such as logging, telemetry, or rate limiting. It receives
+// the next handler in the chain and returns a handler that wraps it; call next to
+// pass the command along, or return without calling it to short-circuit.
 //
-// Parameters:
-//   - next: The next handler in the chain. Call it to pass the command to the following
-//     middleware or the final registered handler.
-//
-// Returns:
-//   - A wrapped handler that intercepts command execution.
-//
-// Notes:
-//   - The first middleware passed to Use() is the outermost wrapper and executes first on each dispatch.
+// The chain is baked into a handler once, by [Register], from the middlewares
+// added via [CommandBus.Use] up to that moment. Add all middleware during startup
+// wiring, before registering any handler. The first middleware passed to Use is
+// the outermost wrapper and runs first on each dispatch.
 //
 // Example Usage:
 //
@@ -31,15 +27,13 @@ import "context"
 //	bus.Use(rateLimiter)
 type CommandHandlerMiddleware func(next CommandHandler[Command]) CommandHandler[Command]
 
-// Use adds one or more middlewares to the CommandBus and immediately re-wraps every
-// registered command handler with the updated chain.
+// Use appends middlewares to the chain applied to command handlers. The first
+// one appended is the outermost wrapper and runs first on each dispatch.
 //
-// Parameters:
-//   - middlewares: One or more CommandHandlerMiddleware values to append to the chain.
-//
-// Notes:
-//   - The first middleware in the list is the outermost wrapper and executes first on each dispatch.
-//   - Must be called before Register; middleware is baked into the handler at registration time.
+// Use must be called before [Register]: the chain is baked into each handler at
+// registration time, so handlers already registered are not re-wrapped and a
+// later Use call has no effect on them. Configure the full chain during startup
+// wiring.
 //
 // Example Usage:
 //
@@ -55,23 +49,18 @@ func (b *CommandBus) Use(middlewares ...CommandHandlerMiddleware) {
 	}
 }
 
-// QueryHandlerMiddleware defines a function type for decorating query handlers on the QueryBus.
-// Registering one or more middlewares via Use() causes every query handler — regardless of
-// when it was registered — to be wrapped with the full middleware chain.
+// QueryHandlerMiddleware decorates a query handler on a [QueryBus]. It receives
+// the next handler in the chain and returns a handler that wraps it; call next to
+// pass the query along, or return without calling it to short-circuit.
 //
-// The query is received as a Query interface, so qry.ID() is available directly.
-// Use fmt.Sprintf("%T", qry) to retrieve the concrete query type name.
-// The result is received as any and holds the concrete result value.
+// The query arrives as a [Query], so qry.ID is available directly; use
+// fmt.Sprintf("%T", qry) for the concrete type name. The result arrives as an any
+// holding the concrete result value.
 //
-// Parameters:
-//   - next: The next handler in the chain. Call it to pass the query to the following
-//     middleware or the final registered handler.
-//
-// Returns:
-//   - A wrapped handler that intercepts query execution.
-//
-// Notes:
-//   - The first middleware passed to Use() is the outermost wrapper and executes first on each query.
+// The chain is baked into a handler once, by [RegisterQueryHandler], from the
+// middlewares added via [QueryBus.Use] up to that moment. Add all middleware
+// during startup wiring, before registering any handler. The first middleware
+// passed to Use is the outermost wrapper and runs first on each query.
 //
 // Example Usage:
 //

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -181,6 +181,30 @@ func TestCommandBusMiddlewareAppliedAtRegister(t *testing.T) {
 	}
 }
 
+// TestCommandBusMiddlewareNotAppliedAfterRegister pins the other half of the
+// contract documented on Use: the chain is baked into a handler at Register
+// time, so Use is startup wiring only and middleware added afterwards
+// deliberately does not wrap handlers that are already registered.
+func TestCommandBusMiddlewareNotAppliedAfterRegister(t *testing.T) {
+	bus := NewCommandBus(10, 1)
+	defer bus.Stop()
+
+	Register(bus, func(ctx context.Context, cmd testCmd) (AppendResult, error) {
+		return AppendResult{Successful: true}, nil
+	})
+
+	late := &mwTestCommandMiddleware{}
+	bus.Use(late.Middleware)
+
+	if _, err := bus.Dispatch(context.Background(), testCmd{ID: "x"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if late.timesCalled != 0 {
+		t.Fatalf("middleware added after Register must not wrap that handler; got %d calls", late.timesCalled)
+	}
+}
+
 func TestCommandBusFuncAndStructMiddleware(t *testing.T) {
 	bus := NewCommandBus(10, 1)
 	defer bus.Stop()


### PR DESCRIPTION
Fixes #21

## The problem

`Use`s doc comment promised:

> Use adds one or more middlewares to the CommandBus and **immediately re-wraps every registered command handler** with the updated chain.

It does not do that. `Use` only appends to `b.middlewares`; the chain is baked into each handler once, by `Register`, from the middlewares present at that moment:

```go
for i := len(b.middlewares) - 1; i >= 0; i-- {
	h = b.middlewares[i](h)
}
b.handlers[cmdName] = h
```

Nothing ever re-derives `b.handlers` afterwards, so a handler registered before a later `Use` call silently never runs that middleware.

Meanwhile `Register`s own comment already stated the opposite, correct contract:

> The middleware chain is applied at registration time; call Use before Register.

So the two comments in the same package directly contradicted each other about supported call order.

## Resolution: fix the docs, not the code

**The behaviour is intentional.** `Use` is startup wiring, which keeps the dispatch hot path from having to walk a mutable middleware slice on every command. This PR takes that side of the contradiction.

The behavioural alternative — having `Use` rebuild every `b.handlers` entry — was explicitly **not** taken. It would also have required resolving the unlocked `b.handlers` read in `worker` first (#22), since `Use` would then be mutating `b.handlers` concurrently with dispatch.

## Changes

- **`CommandBus.Use`** — dropped the "immediately re-wraps" claim; states plainly that already-registered handlers are not re-wrapped and that a later `Use` has no effect on them.
- **`CommandHandlerMiddleware`** — carried the same false claim ("regardless of when it was registered"), same fix.
- **`QueryHandlerMiddleware`** — identical false claim. `QueryBus.Use` has the same semantics, with the chain baked in by `RegisterQueryHandler`, so it was wrong in exactly the same way.

Also rewrote these comments as prose per [go.dev/doc/comment](https://go.dev/doc/comment). The `Parameters:`/`Returns:`/`Notes:` blocks are not godoc headings — a heading needs a leading `# ` — so they rendered as stray one-line paragraphs rather than the sections they were meant to be. Added doc links so pkg.go.dev hyperlinks the symbols mentioned.

## Verification

`TestCommandBusMiddlewareNotAppliedAfterRegister` pins the newly documented half of the contract. The supported call order was already covered by the existing `TestCommandBusMiddlewareAppliedAtRegister`, so no duplicate was added. Suite green under `go test -race`.