### PR TITLE
Guard the worker's b.handlers read with a read lock

### DIFF
--- a/command_bus.go
+++ b/command_bus.go
@@ -44,7 +44,7 @@ type CommandBus struct {
 	stopCh      chan struct{}
 	stopOnce    sync.Once
 	wg          sync.WaitGroup
-	mu          sync.Mutex
+	mu          sync.RWMutex
 	shardCount  int
 	middlewares []CommandHandlerMiddleware
 }
@@ -97,17 +97,18 @@ func NewCommandBus(bufferSize int, shardCount int) *CommandBus {
 func (b *CommandBus) Dispatch(ctx context.Context, cmd Command) (AppendResult, error) {
 	// Registering as in-flight must be atomic with the stopCh check: sync.WaitGroup
 	// forbids an Add that races a Wait, and Stop calls Wait as soon as it has closed
-	// stopCh. Holding b.mu across both makes every Add happen-before that close, so
-	// Stop is a real barrier and go test -race stays clean.
-	b.mu.Lock()
+	// stopCh. Stop takes the write lock to close, so it waits out every reader here
+	// and every Add happens-before the close. Concurrent dispatches hold the read
+	// lock together and do not serialize.
+	b.mu.RLock()
 	select {
 	case <-b.stopCh:
-		b.mu.Unlock()
+		b.mu.RUnlock()
 		return AppendResult{Successful: false}, fmt.Errorf("dispatch command %T for aggregate %q: %w", cmd, cmd.AggregateID(), ErrCommandBusClosed)
 	default:
 	}
 	b.wg.Add(1)
-	b.mu.Unlock()
+	b.mu.RUnlock()
 	defer b.wg.Done()
 
 	responseCh := make(chan commandResult, 1)
@@ -154,7 +155,7 @@ func (b *CommandBus) worker(queue chan queuedCommand) {
 
 		cmdName := fmt.Sprintf("%T", cmd.Command)
 
-		h, exists := b.handlers[cmdName]
+		h, exists := b.handlerFor(cmdName)
 
 		if !exists {
 			cmd.ResponseCh <- commandResult{
@@ -198,23 +199,31 @@ func (b *CommandBus) worker(queue chan queuedCommand) {
 	}
 }
 
+// handlerFor returns the handler registered for cmdName, and reports whether one
+// exists. The lock is held only for the map lookup, never for the handler call,
+// so a slow handler cannot block Register.
+func (b *CommandBus) handlerFor(cmdName string) (CommandHandler[Command], bool) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	h, ok := b.handlers[cmdName]
+	return h, ok
+}
+
 func (b *CommandBus) selectShard(aggregateID string) int {
 	hash := fnv.New32a()
 	hash.Write([]byte(aggregateID))
 	return int(hash.Sum32()) % b.shardCount
 }
 
-// Register adds a new typed command handler to the bus.
+// Register installs handler as the handler for command type C on b. The
+// registration key is derived from C with fmt.Sprintf("%T"), so there are no
+// manual type strings to keep in sync. Register panics with
+// [ErrDuplicateHandler] if a handler for C is already registered.
 //
-// Parameters:
-//   - b: pointer to the CommandBus
-//   - handler: a generic CommandHandler[Command] function for a specific command type C
-//
-// Notes:
-//   - Derives the command type name automatically using fmt.Sprintf("%T") to avoid
-//     manual registration strings.
-//   - Panics if a handler is already registered for the same command type.
-//   - The middleware chain is applied at registration time; call Use before Register.
+// The middleware chain is applied here, at registration time, from the
+// middlewares added via [CommandBus.Use] up to this point — so call Use first.
+// Register is safe to call on a bus that is already dispatching, though wiring
+// every handler during startup is the expected pattern.
 //
 // Example:
 //

--- a/command_bus_test.go
+++ b/command_bus_test.go
@@ -264,6 +264,87 @@ func TestCommandBus_StopIsIdempotent(t *testing.T) {
 	bus.Stop() // must not panic
 }
 
+// Command types used only by TestCommandBus_RegisterWhileDispatching. Each
+// Register call writes a new key into bus.handlers, which is what used to race
+// with the worker goroutine's read.
+type raceCmdA struct{ ID string }
+
+func (c raceCmdA) AggregateID() string { return c.ID }
+
+type raceCmdB struct{ ID string }
+
+func (c raceCmdB) AggregateID() string { return c.ID }
+
+type raceCmdC struct{ ID string }
+
+func (c raceCmdC) AggregateID() string { return c.ID }
+
+type raceCmdD struct{ ID string }
+
+func (c raceCmdD) AggregateID() string { return c.ID }
+
+type raceCmdE struct{ ID string }
+
+func (c raceCmdE) AggregateID() string { return c.ID }
+
+// TestCommandBus_RegisterWhileDispatching asserts the concurrency contract the
+// CommandBus godoc promises: the type carries "synchronization mechanisms for
+// safe concurrent access" and Dispatch "is safe to call concurrently".
+// Registering a handler on a live bus while commands are in flight must
+// therefore be race-free. The worker's map read used to be unguarded, which
+// aborted the process with "fatal error: concurrent map read and map write".
+func TestCommandBus_RegisterWhileDispatching(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		bus := NewCommandBus(64, 1)
+
+		Register(bus, func(ctx context.Context, cmd raceCmdA) (AppendResult, error) {
+			return AppendResult{Successful: true}, nil
+		})
+
+		// Keep the worker busy reading b.handlers, and signal once it is
+		// actually draining the queue so the registrations below overlap it.
+		var wg sync.WaitGroup
+		running := make(chan struct{})
+		stop := make(chan struct{})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var once sync.Once
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, err := bus.Dispatch(context.Background(), raceCmdA{ID: "a"}); err != nil {
+					return
+				}
+				once.Do(func() { close(running) })
+			}
+		}()
+
+		<-running
+
+		// Concurrently register further handlers, each writing b.handlers.
+		Register(bus, func(ctx context.Context, cmd raceCmdB) (AppendResult, error) {
+			return AppendResult{Successful: true}, nil
+		})
+		Register(bus, func(ctx context.Context, cmd raceCmdC) (AppendResult, error) {
+			return AppendResult{Successful: true}, nil
+		})
+		Register(bus, func(ctx context.Context, cmd raceCmdD) (AppendResult, error) {
+			return AppendResult{Successful: true}, nil
+		})
+		Register(bus, func(ctx context.Context, cmd raceCmdE) (AppendResult, error) {
+			return AppendResult{Successful: true}, nil
+		})
+
+		close(stop)
+		wg.Wait()
+		bus.Stop()
+	}
+}
+
 type benchCmd struct{ ID string }
 
 func (c benchCmd) AggregateID() string { return c.ID }

--- a/docs/reference/command-bus.md
+++ b/docs/reference/command-bus.md
@@ -22,7 +22,7 @@ func NewCommandBus(bufferSize int, shardCount int) *CommandBus
 | Parameter | Description |
 |---|---|
 | `bufferSize` | Size of the internal buffered channel per shard. |
-| `shardCount` | Number of shards (workers). Must be > 0. Commands for the same `AggregateID` always go to the same shard (FNV hash). |
+| `shardCount` | Number of shards (workers). Values `<= 0` are coerced to `1`. Commands for the same `AggregateID` always go to the same shard (FNV hash). |
 
 ```go
 bus := eventsourcing.NewCommandBus(100, 4)
@@ -37,6 +37,8 @@ func Register[C Command](b *CommandBus, handler CommandHandler[C])
 ```
 
 Registers a typed handler. **Panics** if a handler is already registered for the same command type.
+
+The middleware chain is applied here, at registration time — so call [`Use()`](../how-to/use-middleware.md) before `Register`. `Register` is safe to call on a bus that is already dispatching, though wiring every handler during startup is the expected pattern.
 
 ```go
 eventsourcing.Register(bus, createTaskHandler)
@@ -67,11 +69,15 @@ result, err := bus.Dispatch(ctx, CreateTask{...})
 func (b *CommandBus) Stop()
 ```
 
-Stops accepting new commands, closes all internal queues, and waits for all in-flight commands to complete. Call this during graceful shutdown.
+Stops accepting new commands, lets the workers finish whatever is already queued, and waits for all in-flight commands to complete before returning. Call this during graceful shutdown.
+
+A `Dispatch` racing `Stop` either completes normally or returns `ErrCommandBusClosed` — it never panics. `Stop` is idempotent and safe to call concurrently, but the bus cannot be restarted afterwards.
 
 ```go
 defer bus.Stop()
 ```
+
+Because `Stop` waits for in-flight commands, it is safe to tear down the event store immediately after it returns.
 
 ---
 


### PR DESCRIPTION
Fixes #22

## The bug

Every worker goroutine looked up `b.handlers[cmdName]` with no lock, while `Register` wrote that same map under `b.mu`:

```go
// worker — read, no lock
h, exists := b.handlers[cmdName]

// Register — write under b.mu
b.handlers[cmdName] = h
```

So `b.mu` protected writers against each other and nothing else.

**The failure mode is worse than an ordinary race.** Under `-race` it reports `WARNING: DATA RACE`. In a normal build the runtime's concurrent-map guard fires:

```
fatal error: concurrent map read and map write
```

That is a runtime *throw*, not a panic. The `recover()` in `worker` cannot catch it, so the type's documented "panic recovery in handlers to prevent the bus from crashing" guarantee does not apply — the entire process dies.

`NewCommandBus` starts its workers inside the constructor, so there is no pre-start window: every `Register` call is by construction a call on a live bus.

## Why not just document it as startup-only

That is how #21 was resolved for `Use`, and the report raises the same option here. Rejected, for three reasons:

1. **The failure mode.** #21's violation is "middleware silently does not run." This one aborts the process, unrecoverably.
2. **Nothing enforces or signals it.** No `Start()`, no sealed state, no error at the call site. Someone registering lazily gets a crash later under load.
3. **The docs promise the opposite.** The type doc claims "synchronization mechanisms for safe concurrent access" and `Dispatch` says "safe to call concurrently." Documenting this away means retracting a *safety* claim.

## The fix

`b.mu` promoted to `sync.RWMutex`, with the worker's lookup behind an accessor:

```go
func (b *CommandBus) handlerFor(cmdName string) (CommandHandler[Command], bool) {
	b.mu.RLock()
	defer b.mu.RUnlock()
	h, ok := b.handlers[cmdName]
	return h, ok
}
```

The lock is held only for the map lookup, never across `h(...)`, so a slow handler cannot block `Register`.

### Interaction with #61

`Dispatch`'s lock — added in #61 to order `wg.Add` against `Stop`'s `wg.Wait` — becomes `RLock`. Still correct: `Stop` takes the *write* lock to close `stopCh`, so it waits out every in-flight reader before calling `Wait`, and concurrent `wg.Add` calls are safe. And concurrent dispatches no longer serialize on it, which resolves the objection to putting a plain `Mutex` on the sharded dispatch path.

One `RWMutex` now does both jobs: `RLock` in `Dispatch` for the ordering *and* the handler lookup, `Lock` in `Register`/`Use`/`Stop`.

### Cost

| Benchmark | #61 (`Mutex`) | this PR (`RWMutex`) |
|---|---|---|
| shards=1 | 725.8 ns/op | 728.7 ns/op |
| shards=8 | 749.6 ns/op | 757.3 ns/op |
| shards=32 | 783.3 ns/op | 798.1 ns/op |
| contended, 512 goroutines | 638.0 ns/op | **629.8 ns/op** |

The extra per-command `RLock` costs ~1–2% at high shard counts. The contended case *improved*, because readers no longer queue behind each other.

## Verification

`TestCommandBus_RegisterWhileDispatching` (50 iterations, registrations overlapping a live dispatch loop) moved into `command_bus_test.go` and unskipped. Previously it reproduced on every run — `DATA RACE` under `-race`, `fatal error` without. Now green on both, plus `go test -race -count=5 ./...` across all packages.

## Docs

Also carries a `docs/reference/command-bus.md` correction that **missed the #61 squash**: the page still claimed `Stop` "closes all internal queues", which is exactly the behaviour #61 removed. Documents `Register`'s actual concurrency contract too, and corrects the claim that `shardCount` "Must be > 0" — `NewCommandBus` silently coerces `<= 0` to `1`, which `TestNewCommandBus` already covers.