### PR TITLE
Fix RegisterEvent returning a shared instance for every registration

### DIFF
--- a/docs/reference/event-registry.md
+++ b/docs/reference/event-registry.md
@@ -7,10 +7,14 @@ The event registry maps event type names to factory functions. Persistent event 
 ### RegisterEvent
 
 ```go
-var RegisterEvent func(event Event)
+func RegisterEvent[T any, PT eventPtr[T]](_ PT)
 ```
 
-Registers an event type using its `EventType()` name as the key.
+Registers an event type using its `EventType()` name as the key. The pointer
+passed in is only used to infer the concrete type `T`; the value itself is
+discarded. Each subsequent lookup gets a genuinely new `new(T)` instance —
+built at the type level via generics, not via reflection — so decoding two
+stored events never lets one overwrite the other's fields.
 
 ```go
 eventsourcing.RegisterEvent(&events.TaskCreated{})
@@ -82,7 +86,7 @@ Used internally by `EventGroupProcessor.StreamFilter()`.
 
 ## Behaviour notes
 
-- All registration functions are **package-level variables**. They can be replaced in tests to inject alternative implementations.
+- `RegisterEventByType`, `RegisterEventByName`, `NewEventByName`, and `EventNamesFor` are **package-level variables** and can be replaced in tests to inject alternative implementations. `RegisterEvent` is a generic function and cannot be replaced this way — swap `RegisterEventByType` instead if you need to intercept registration.
 - Registration **panics** on nil factory, nil result, empty name, or duplicate name.
 - The registry is protected by a `sync.RWMutex` and is safe for concurrent reads.
 - Register all events at startup (typically in `init()` functions or `main()`).

--- a/event_registry.go
+++ b/event_registry.go
@@ -16,30 +16,6 @@ var (
 	// registryMu protects access to the registry for concurrent operations.
 	registryMu sync.RWMutex
 
-	// RegisterEvent registers a new Event type using its default type name.
-	//
-	// It provides a reusable pattern for dynamically creating new event instances
-	// by string name. Registration performs the following steps:
-	//   1. Calls the provided factory function to obtain an instance of the event.
-	//   2. Retrieves the type name using EventType().
-	//   3. Registers the factory in the registry keyed by the type name.
-	//
-	// Parameters:
-	//   - event: A factory function of type func() Event that returns a new instance
-	//     of the event. The factory must not return nil.
-	//
-	// Panics:
-	//   - If the factory function is nil.
-	//   - If the factory returns nil.
-	//   - If an event with the same type name is already registered.
-	//
-	// Example Usage:
-	//   RegisterEvent(OrderCreated{})
-	RegisterEvent func(event Event) = func(event Event) {
-		RegisterEventByType(func() Event {
-			return event
-		})
-	}
 	// RegisterEventByType registers a new Event type using its default type name.
 	//
 	// It provides a reusable pattern for dynamically creating new event instances
@@ -111,6 +87,40 @@ var (
 		return typeToNames[fmt.Sprintf("%T", event)]
 	}
 )
+
+// eventPtr constrains PT to be a pointer to T that also implements Event.
+//
+// It lets RegisterEvent mint a genuinely new instance via new(T) for each
+// registration, the same way InitialState[T] lets a caller supply a factory
+// for T — except here the factory is derived from the type itself instead
+// of reflect, so no runtime type inspection is needed.
+type eventPtr[T any] interface {
+	*T
+	Event
+}
+
+// RegisterEvent registers a new Event type using its default type name.
+//
+// Unlike RegisterEventByType and RegisterEventByName, RegisterEvent does not
+// take a factory function. Instead it infers the concrete type T from the
+// pointer passed in and builds its own factory that returns new(T) on every
+// call, so each registration is guaranteed a fresh instance without reflect
+// and without the caller having to write out a closure.
+//
+// Parameters:
+//   - _: A pointer to a zero-value instance of the event, used only to infer
+//     its concrete type. The value itself is discarded.
+//
+// Panics:
+//   - If an event with the same type name is already registered.
+//
+// Example Usage:
+//   RegisterEvent(&OrderCreated{})
+func RegisterEvent[T any, PT eventPtr[T]](_ PT) {
+	RegisterEventByType(func() Event {
+		return PT(new(T))
+	})
+}
 
 // registerEventNameDefault is the internal implementation for registering an event under a name.
 //

--- a/event_registry_test.go
+++ b/event_registry_test.go
@@ -1,6 +1,7 @@
 package eventsourcing
 
 import (
+	"encoding/json"
 	"strconv"
 	"sync"
 	"testing"
@@ -204,5 +205,85 @@ func TestFactoryReturnsNil(t *testing.T) {
 	// Register a factory that returns nil
 	RegisterEventByName("NilFactory", func() Event {
 		return nil
+	})
+}
+
+// SharedEvent mimics a normal domain event as documented in
+// docs/how-to/register-events.md: a pointer type registered with RegisterEvent.
+type SharedEvent struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func (e *SharedEvent) EventType() string   { return "SharedEvent" }
+func (e *SharedEvent) AggregateID() string { return e.ID }
+
+func resetRegistry(t *testing.T) {
+	t.Helper()
+	registryMu.Lock()
+	registry = map[string]func() Event{}
+	typeToNames = map[string][]string{}
+	registryMu.Unlock()
+}
+
+// TestRegisterEventReturnsNewInstance asserts the invariant documented on the
+// registry ("Each factory must return a new instance of a concrete Event type")
+// and already enforced for RegisterEventByType in TestRegisterEventByType.
+func TestRegisterEventReturnsNewInstance(t *testing.T) {
+	t.Run("distinct instances", func(t *testing.T) {
+		resetRegistry(t)
+
+		RegisterEvent(&SharedEvent{})
+
+		ev1, err := NewEventByName("SharedEvent")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ev2, err := NewEventByName("SharedEvent")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if ev1 == ev2 {
+			t.Fatalf("factory returned the same instance twice: %p", ev1)
+		}
+
+		ev1.(*SharedEvent).Name = "first"
+		if got := ev2.(*SharedEvent).Name; got != "" {
+			t.Fatalf("mutating one instance leaked into the other: got %q, want %q", got, "")
+		}
+	})
+
+	// This reproduces the exact decode path used by every persistent event
+	// store, e.g. eventstore/file/filestorage.go:231-239 and
+	// eventstore/postgres/eventstore.go:268.
+	t.Run("decoding two stored events yields independent values", func(t *testing.T) {
+		resetRegistry(t)
+
+		RegisterEvent(&SharedEvent{})
+
+		stored := [][]byte{
+			[]byte(`{"id":"agg-1","name":"first"}`),
+			[]byte(`{"id":"agg-1","name":"second"}`),
+		}
+
+		decoded := make([]Event, 0, len(stored))
+		for _, data := range stored {
+			ev, err := NewEventByName("SharedEvent")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := json.Unmarshal(data, &ev); err != nil {
+				t.Fatal(err)
+			}
+			decoded = append(decoded, ev)
+		}
+
+		want := []string{"first", "second"}
+		for i, ev := range decoded {
+			if got := ev.(*SharedEvent).Name; got != want[i] {
+				t.Errorf("decoded[%d].Name = %q, want %q", i, got, want[i])
+			}
+		}
 	})
 }


### PR DESCRIPTION
## Summary
- `RegisterEvent` closed over the single `Event` value it was given and returned that same pointer from every subsequent lookup, so decoding multiple stored events of the same type via `NewEventByName` + `json.Unmarshal` silently corrupted earlier events with later data.
- `RegisterEvent` is now a generic function that infers the concrete type from the pointer passed in and mints a genuinely new instance via `new(T)` on every registration lookup — no reflection involved.
- Updated `docs/reference/event-registry.md` to reflect the new signature and the fact that `RegisterEvent` (unlike its siblings) is no longer a swappable package-level variable.

Fixes #54

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test .` — `TestRegisterEventReturnsNewInstance` (both subtests: distinct instances, and decoding two stored events yields independent values) now passes