### PR TITLE
Rewrite doc comments to follow go.dev/doc/comment conventions

### DIFF
--- a/command.go
+++ b/command.go
@@ -1,21 +1,11 @@
 package eventsourcing
 
-// Command represents a user or system intention to perform an action on a specific domain entity.
+// Command represents a user or system's intent to perform an action on a
+// specific domain entity.
 //
-// A Command models **intent**, not implementation. It should describe **what the user or system wants to achieve**,
-// in terms that are meaningful to the business or domain experts.
-//
-// Key guidelines for designing Commands:
-//
-// 1. **Name by intent, not technical detail**:
-//
-//   - The name should clearly describe the intention or purpose of the action.
-//
-//   - Avoid generic or mechanical terms like "Updated" or "Change".
-//
-//     Example command names and their intent:
-//
-// Example command names and their intent:
+// A Command models intent, not implementation: name it after what the user
+// or system wants to achieve, in terms meaningful to the domain, rather than
+// generic or mechanical terms like "Updated" or "Change". For example:
 //
 //	Command Name      Intent
 //	---------------- ----------------------------------------
@@ -26,30 +16,23 @@ package eventsourcing
 //	ShipOrder         Ship a customer order
 //	CreateAccount     Create a new user account
 //
-// 2. **Aggregate target**:
-//   - Every Command must identify the entity it targets through `AggregateID()` (or a similar method in your domain model).
-//   - This allows the handler to locate the relevant state.
-//
-// 3. **Immutability**:
-//   - Commands should be immutable after creation. They represent a fixed intention at a point in time.
-//
-// 4. **Self-contained**:
-//   - Include all information necessary for the Command to be handled correctly.
-//   - Do not rely on hidden state or external assumptions.
-//
-// Example:
+// Every Command must identify the entity it targets through
+// [Command.AggregateID], so a handler can locate that entity's state. A
+// Command should be immutable after creation, representing a fixed
+// intention at a point in time, and self-contained, carrying everything
+// needed to handle it rather than relying on hidden state. For example:
 //
 //	type ReserveSeat struct {
-//	    ScreeningID string
-//	    SeatNumber  string
-//	    UserID      string
+//		ScreeningID string
+//		SeatNumber  string
+//		UserID      string
 //	}
 //
 //	func (c ReserveSeat) AggregateID() string {
-//	    return c.ScreeningID
+//		return c.ScreeningID
 //	}
 type Command interface {
-	// AggregateID returns the ID of the entity this command targets.
-	// This ID is used to locate the entity in the system for processing the command.
+	// AggregateID returns the ID of the entity this command targets, used to
+	// locate that entity's state when handling the command.
 	AggregateID() string
 }

--- a/command_bus.go
+++ b/command_bus.go
@@ -8,36 +8,35 @@ import (
 	"sync"
 )
 
+// Dispatcher has the same signature as [CommandBus.Dispatch], for code that
+// wants to depend on the dispatch behavior without depending on *CommandBus
+// itself.
 type Dispatcher interface {
 	Dispatch(ctx context.Context, cmd Command) (AppendResult, error)
 }
 
-// queuedCommand represents a command enqueued in the command bus for processing.
-// Each queuedCommand includes the context for cancellation, the command itself,
-// and a response channel to return the processing result.
+// queuedCommand is a command enqueued on a [CommandBus] shard, carrying the
+// context to honor for cancellation and the channel to deliver the result on.
 type queuedCommand struct {
 	Ctx        context.Context
 	Command    Command
 	ResponseCh chan<- commandResult
 }
 
-// commandResult represents the result of processing a command.
-// It contains the AppendResult (success/failure metadata) and any error
-// encountered during command handling.
+// commandResult is the outcome of processing a queuedCommand: the resulting
+// [AppendResult] and any error from the handler.
 type commandResult struct {
 	Result AppendResult
 	Err    error
 }
 
-// CommandBus is an internal, in-memory, type-safe command dispatcher.
-// It maintains a mapping of command type names to their handlers, a queues for
-// incoming commands, and synchronization mechanisms for safe concurrent access.
-//
-// The CommandBus supports:
-//   - Enqueuing commands for asynchronous processing
-//   - Typed command registration using generics
-//   - Safe shutdown that waits for in-flight commands to complete
-//   - Panic recovery in handlers to prevent the bus from crashing
+// CommandBus is an in-memory, type-safe command dispatcher. It keeps a
+// registry of command type names to handlers, sharded queues of incoming
+// commands, and the synchronization needed for concurrent [Dispatch] and
+// [Register] calls. Commands for a given aggregate are always routed to the
+// same shard and processed one at a time, [Stop] waits for in-flight
+// dispatches to finish, and a handler panic is recovered rather than
+// crashing the bus.
 type CommandBus struct {
 	handlers    map[string]CommandHandler[Command]
 	queues      []chan queuedCommand
@@ -49,18 +48,13 @@ type CommandBus struct {
 	middlewares []CommandHandlerMiddleware
 }
 
-// NewCommandBus creates a new instance of CommandBus with a buffered queues.
-//
-// Parameters:
-//   - bufferSize: the size of the internal queues for enqueued commands.
-//
-// Returns:
-//   - pointer to a newly initialized CommandBus. The internal processing
-//     goroutine is started automatically.
+// NewCommandBus returns a [CommandBus] with shardCount shards, each with a
+// worker goroutine already running and a queue buffering up to bufferSize
+// commands. shardCount is clamped to at least 1.
 //
 // Example:
 //
-//	bus := NewCommandBus(100)
+//	bus := NewCommandBus(100, 4)
 func NewCommandBus(bufferSize int, shardCount int) *CommandBus {
 
 	if shardCount <= 0 {
@@ -136,7 +130,7 @@ func (b *CommandBus) Dispatch(ctx context.Context, cmd Command) (AppendResult, e
 	}
 }
 
-// worker processes commands from a single shard queues.
+// worker processes commands from a single shard's queue.
 func (b *CommandBus) worker(queue chan queuedCommand) {
 
 	for {

--- a/command_handler.go
+++ b/command_handler.go
@@ -10,57 +10,39 @@ import (
 	"github.com/google/uuid"
 )
 
-// StreamNamer produces the stream name for a given command, with access to context
+// StreamNamer maps a [Command] to the name of the event stream it belongs to.
 type StreamNamer func(ctx context.Context, cmd Command) string
 
-// DefaultStreamNamer is the default function used to determine the stream name
-// for a given command when no custom StreamNamer is provided.
+// DefaultStreamNamer is the [StreamNamer] used by command handlers when no
+// custom namer is configured. By default it returns the command's
+// [Command.AggregateID] as the stream name.
 //
-// By default, it returns the AggregateID of the command as the stream name.
+// It can be overridden globally, for example to add tenant prefixes for
+// multi-tenancy. Override it during program initialization, before any
+// handler runs, to avoid data races on the global.
 //
-// This variable can be overridden globally to change the default behavior
-// for all command handlers, for example to support multi-tenancy, prefixes,
-// or other custom naming conventions.
-//
-// Example usage:
-//
-//	// Default behavior uses AggregateID
-//	stream := DefaultStreamNamer(ctx, myCommand)
-//
-//	// Override globally
+//	// During startup:
 //	DefaultStreamNamer = func(ctx context.Context, cmd Command) string {
-//	    tenant := ctx.Value("tenant").(string)
-//	    return fmt.Sprintf("%s-orders-%s", tenant, cmd.AggregateID())
+//		tenant, _ := ctx.Value(tenantKey).(string)
+//		return fmt.Sprintf("%s-orders-%s", tenant, cmd.AggregateID())
 //	}
 var DefaultStreamNamer StreamNamer = func(ctx context.Context, cmd Command) string {
 	return cmd.AggregateID()
 }
 
-// CommandHandler defines a function type for handling commands of a specific type.
+// CommandHandler handles commands of the concrete type C, which must
+// implement [Command]. A handler carries out the business logic for a
+// command — validating it, deciding what should happen, and persisting any
+// resulting events — and is typically registered with a [CommandBus] via
+// [Register], which dispatches each command to the handler registered for
+// its type.
 //
-// C represents the concrete command type implementing the Command interface.
-//
-// A CommandHandler is responsible for implementing the business logic associated
-// with a command. This typically includes validation, orchestration, and producing
-// side effects, such as persisting events to an EventStore or triggering other operations.
-//
-// Handlers of this type are generally registered with a CommandBus, which ensures that
-// commands are dispatched to the correct handler based on their type.
-//
-// Parameters:
-//   - ctx: The context for controlling cancellation, deadlines, and carrying request-scoped values.
-//   - command: The command of type C, representing the intent to perform a domain action.
-//
-// Returns:
-//   - AppendResult: Represents the result of handling the command, including success status,
-//     the next expected version of the aggregate, and any events that were persisted.
-//   - error: Non-nil if the command handling failed, e.g., due to validation errors, business rule violations,
-//     or persistence failures.
-//
-// Notes:
-//   - Implementations should treat the command as immutable.
-//   - Any domain state changes should be expressed via events (AppendResult.Events) rather than directly mutating state.
-//   - Handlers should not panic; all errors should be returned via the error return value.
+// It returns an [AppendResult] describing the outcome and a non-nil error
+// if handling failed, for example due to a validation error, a business-rule
+// violation, or a persistence failure. Implementations should treat the
+// command as immutable, express state changes as events persisted to an
+// [EventStore] rather than by mutating in-memory state, and return errors
+// rather than panicking.
 //
 // Example Usage:
 //
@@ -68,103 +50,57 @@ var DefaultStreamNamer StreamNamer = func(ctx context.Context, cmd Command) stri
 //	    if seatAlreadyReserved(cmd.SeatNumber) {
 //	        return AppendResult{Successful: false}, fmt.Errorf("seat already reserved")
 //	    }
-//	    events := []Event{SeatReserved{SeatNumber: cmd.SeatNumber, UserID: cmd.UserID}}
-//	    return AppendResult{Successful: true, Events: events}, nil
+//	    // persist a SeatReserved event via an EventStore, then:
+//	    return AppendResult{Successful: true, StreamID: cmd.AggregateID()}, nil
 //	}
 type CommandHandler[C Command] func(ctx context.Context, command C) (AppendResult, error)
 
-// InitialState returns an initial state of type T
-//
-// T represents the aggregate state type.
-//
-// Returns:go
-//   - The initial aggregate state of type T.
-//
-// Notes:
-//   - The InitialState is responsible for returning an initial state
+// InitialState returns the zero-event aggregate state of type T, before any
+// events have been evolved into it — for example, an empty struct or one
+// with its fields set to their defaults.
 type InitialState[T any] func() T
 
-// Evolver evolves the given state into a new state with the event applied.
-//
-// T represents the aggregate state type.
-//
-// Parameters:
-//   - currentState: The current aggregate state.
-//   - envelope: A Envelope object representing an historical event
-//     of an aggregate.
-//
-// Returns:
-//   - The reconstructed aggregate state of type T.
-//
-// Notes:
-//   - The Evolver is responsible for applying the event to the
-//     current state, producing the latest state.
+// Evolver applies a single historical event to currentState and returns the
+// resulting aggregate state of type T. It must not mutate currentState;
+// [NewCommandHandler] calls it once per event, in stream order, folding the
+// result of each call into the next.
 type Evolver[T any] func(currentState T, envelope *Envelope) T
 
-// Decider determines which events should occur based on the current state and a command.
-//
-// T represents the aggregate state type.
-// C represents the command type.
-//
-// Parameters:
-//   - state: The current aggregate state as returned by the Evolver.
-//   - cmd: The command to handle, containing the intent to change state.
-//
-// Returns:
-//   - A slice of Event representing the events that should be applied to the aggregate.
-//   - An error, which should be non-nil if the command violates business rules
-//     or cannot be applied to the current state.
-//
-// Notes:
-//   - The Decider should not mutate the input state directly; it should produce
-//     events that, when applied via the Evolver, will update the state accordingly.
-//   - Returning an empty slice indicates that the command produces no events
-//     (e.g., it was idempotent or had no effect).
+// Decider inspects state, as produced by an [Evolver], against cmd and
+// returns the events that should occur as a result, or a non-nil error if
+// cmd violates a business rule or cannot be applied to state. It must not
+// mutate state; state changes are expressed only through the returned
+// events. An empty, nil slice means cmd produces no events, for example
+// because it was idempotent or had no effect.
 type Decider[T any, C Command] func(state T, cmd C) ([]Event, error)
 
-// CommandHandlerOption defines a function type that modifies handlerOptions.
-// These options are applied when constructing a NewCommandHandler to customize behavior.
+// CommandHandlerOption configures a [CommandHandler] built by
+// [NewCommandHandler].
 type CommandHandlerOption func(configuration *handlerOptions)
 
 // NewCommandHandler returns a generic command handler for any aggregate type.
 //
-// It provides a reusable pattern for handling commands in an event-sourced system
-// by performing the following steps:
-//  1. Load the event history for the aggregate (using LoadStreamFrom).
-//  2. Evolve the current state based on the event history.
-//  3. Decide which new events should occur based on the command and current state.
-//  4. Wrap the decided events in envelopes, assigning version numbers and metadata.
-//  5. Persist the envelopes to the EventStore, respecting the configured revision
-//     and concurrency rules.
+// The returned handler, on each call: loads command's stream from store
+// (named by [DefaultStreamNamer], or a [StreamNamer] set via
+// [WithStreamNamer]) using [EventStore.LoadStreamFrom]; folds every loaded
+// event into initialState with evolve; passes the resulting state and the
+// command to decide to get the events to persist; wraps them in
+// [Envelope]s, stamping each with a new UUID, the next sequential version,
+// the current time, and any metadata from functions added via
+// [WithMetadataExtractor]; and saves them with [EventStore.Save] against
+// the [StreamState] configured via [WithStreamState] (default [Any]).
 //
-// Parameters:
-//   - store: The EventStore used to load and persist events.
-//   - initialState: a function of type InitialState[T] that created the initial state for the command.
-//   - evolve: A function of type Evolver[T] that reconstructs aggregate state from a sequence of events.
-//   - decide: A function of type Decider[T, C] that produces events based on the current state and command.
-//   - opts: Optional CommandHandlerOption values for customizing behavior, such as:
-//   - StreamState: The expected stream revision (default is Any).
-//   - RetryAttempts: Number of retries on version conflicts (default 0).
-//
-// Returns:
-//   - A function that takes a context and a command of type C, and returns:
-//   - AppendResult: Contains information about the persistence result, including success
-//     and the next expected version.
-//   - error: Non-nil if the command failed, either due to a business rule violation,
-//     persistence error, or concurrency conflict.
-//
-// Behavior Details:
-//   - The command’s AggregateID() is used to identify the target stream in the EventStore.
-//   - The SeqWithSideEffect wrapper tracks the last version while evolving state.
-//   - If the configured StreamState is Revision, it is updated to the latest version
-//     before saving to ensure optimistic concurrency control.
-//   - If the decide function returns no events, the handler returns a successful result without persisting.
-//   - Each event is wrapped in an Envelope with a new UUID, metadata map, version, and timestamp.
-//   - Errors during loading, evolving, deciding, or saving are propagated with context using errors.Wrap.
+// If decide returns no events, the handler returns a successful
+// [AppendResult] without calling Save. If decide returns a non-nil error,
+// the handler returns it wrapped in an [ErrBusinessRuleViolation]. If Save
+// fails with a [StreamRevisionConflictError], the handler retries the whole
+// load-evolve-decide-save cycle according to the [backoff.BackOff] set via
+// [WithRetryStrategy] (default: no retries); any other Save or load error is
+// returned directly, without retrying.
 //
 // Example Usage:
 //
-//	handler := NewCommandHandler(store, evolveFunc, decideFunc, WithStreamState(Any{}))
+//	handler := NewCommandHandler(store, initialStateFunc, evolveFunc, decideFunc, WithStreamState(Any{}))
 //	result, err := handler(ctx, myCommand)
 func NewCommandHandler[T any, C Command](
 	store EventStore,
@@ -254,6 +190,12 @@ func NewCommandHandler[T any, C Command](
 			}
 
 			// --- Persist events ---
+			// TODO: this always saves against the originally configured
+			// options.Revision, not the Revision(lastVersion) derived from
+			// the stream just loaded above (see the `revision` var, which
+			// tracks it but is never used here). For a fixed Revision
+			// option this makes every retry re-check the same, now-stale,
+			// expectation instead of the current one.
 			result, err := store.Save(ctx, envelopes, options.Revision)
 
 			if err != nil {
@@ -272,22 +214,8 @@ func NewCommandHandler[T any, C Command](
 	}
 }
 
-// handlerOptions defines configuration for a CommandHandler.
-//
-// It is used internally by NewCommandHandler to control behavior such as
-// concurrency checks, retry strategy, and event metadata enrichment.
-//
-// Fields:
-//   - StreamState: Determines the concurrency check applied when saving events.
-//     Defaults to Any{}.
-//   - RetryStrategy: Strategy for retrying operations in case of transient
-//     failures or version conflicts. Defaults to no retries.
-//   - MetadataFuncs: Slice of functions that generate metadata for each event.
-//     Each function receives the context and returns a map of key-value pairs.
-//   - StreamNamer: Function used to determine the stream name for a command.
-//     If nil, DefaultStreamNamer is used, which returns the AggregateID by default.
-//     This can be overridden per handler or globally for custom naming conventions
-//     (e.g., multi-tenancy, dynamic prefixes, or other domain-specific logic).
+// handlerOptions holds the configuration [NewCommandHandler] builds from
+// its [CommandHandlerOption] arguments.
 type handlerOptions struct {
 	// Revision is the condition applied when saving events to the stream.
 	// It determines the concurrency check behavior (default is Any).
@@ -306,25 +234,22 @@ type handlerOptions struct {
 	StreamNamer StreamNamer
 }
 
-// WithStreamState sets the expected stream revision for a NewCommandHandler.
-//
-// The StreamState controls the concurrency check when persisting events. For example:
-//   - Any{}: no version check (default)
-//   - NoStream{}: ensures the stream does not exist
-//   - StreamExists{}: ensures the stream exists
-//   - Revision{N}: expects the stream to be at version N
+// WithStreamState sets the [StreamState] a [NewCommandHandler] expects the
+// stream to be in when it saves events — [Any] (the default) to skip the
+// check, [NoStream] or [StreamExists] to assert existence, or a specific
+// [Revision] to assert an exact version.
 //
 // Usage:
 //
-//	handler := NewCommandHandler(store, initialState, evolve, decide, WithRevision(NoStream))
+//	handler := NewCommandHandler(store, initialState, evolve, decide, WithStreamState(NoStream{}))
 func WithStreamState(rev StreamState) CommandHandlerOption {
 	return func(cfg *handlerOptions) { cfg.Revision = rev }
 }
 
-// WithRetryStrategy sets the retry strategy for a NewCommandHandler.
-//
-// The BackOff strategy controls how many times and with what delay the handler
-// retries saving events in case of concurrency conflicts or transient errors.
+// WithRetryStrategy sets the [backoff.BackOff] a [NewCommandHandler] uses to
+// retry its load-evolve-decide-save cycle after a
+// [StreamRevisionConflictError]. Without this option, no retries are
+// performed and the handler returns the conflict directly.
 //
 // Usage:
 //
@@ -333,11 +258,11 @@ func WithRetryStrategy(strategy backoff.BackOff) CommandHandlerOption {
 	return func(cfg *handlerOptions) { cfg.RetryStrategy = strategy }
 }
 
-// WithMetadataExtractor adds a metadata function to a NewCommandHandler.
-//
-// Each metadata function is called for every command handling execution and can
-// inject additional key-value pairs into the event envelopes. Multiple metadata
-// extractors can be combined; they are applied in order of registration.
+// WithMetadataExtractor adds fn to the metadata functions a
+// [NewCommandHandler] calls for every command, merging their results into
+// each resulting [Envelope]'s Metadata. Multiple extractors can be combined;
+// they run in the order they were added, later ones overwriting keys set by
+// earlier ones.
 //
 // Usage:
 //
@@ -348,11 +273,8 @@ func WithMetadataExtractor(fn func(ctx context.Context) map[string]any) CommandH
 	}
 }
 
-// WithStreamNamer sets a custom stream naming function on a NewCommandHandler.
-//
-// The StreamNamer is called for every command handling execution and determines
-// the stream name used to load and persist events. This allows customization
-// beyond the default behavior of using the command's AggregateID as the stream name.
+// WithStreamNamer overrides the [StreamNamer] a [NewCommandHandler] uses to
+// name the stream it loads and saves to, in place of [DefaultStreamNamer].
 //
 // Usage:
 //

--- a/context.go
+++ b/context.go
@@ -9,7 +9,6 @@ import (
 
 type ctxKey string
 
-// Define constants for context keys
 const (
 	streamIDKey      ctxKey = "streamID"
 	aggregateIDKey   ctxKey = "aggregateID"
@@ -21,7 +20,10 @@ const (
 	causationIDKey   ctxKey = "causationID"
 )
 
-// WithEnvelope adds the context of the Event to the context
+// WithEnvelope returns a copy of ctx carrying env's stream ID, aggregate ID,
+// event ID, version, global version, occurred-at time, and metadata,
+// retrievable via the *FromContext functions below. It does not carry a
+// causation ID; use [WithCausation] for that.
 func WithEnvelope(ctx context.Context, env *Envelope) context.Context {
 	ctx = context.WithValue(ctx, streamIDKey, env.StreamID)
 	ctx = context.WithValue(ctx, aggregateIDKey, env.Event.AggregateID())
@@ -33,7 +35,8 @@ func WithEnvelope(ctx context.Context, env *Envelope) context.Context {
 	return ctx
 }
 
-// AggregateIDFromContext returns the AggregateID or "" if not present
+// AggregateIDFromContext returns the aggregate ID set by [WithEnvelope], or
+// "" if ctx carries none.
 func AggregateIDFromContext(ctx context.Context) string {
 	if v := ctx.Value(aggregateIDKey); v != nil {
 		if s, ok := v.(string); ok {
@@ -43,7 +46,8 @@ func AggregateIDFromContext(ctx context.Context) string {
 	return ""
 }
 
-// StreamIDFromContext returns the StreamID or "" if not present
+// StreamIDFromContext returns the stream ID set by [WithEnvelope], or "" if
+// ctx carries none.
 func StreamIDFromContext(ctx context.Context) string {
 	if v := ctx.Value(streamIDKey); v != nil {
 		if s, ok := v.(string); ok {
@@ -53,7 +57,8 @@ func StreamIDFromContext(ctx context.Context) string {
 	return ""
 }
 
-// EventIDFromContext returns the EventID or uuid.Nil if not present
+// EventIDFromContext returns the event ID set by [WithEnvelope], or
+// [uuid.Nil] if ctx carries none.
 func EventIDFromContext(ctx context.Context) uuid.UUID {
 	if v := ctx.Value(eventIDKey); v != nil {
 		if id, ok := v.(uuid.UUID); ok {
@@ -63,7 +68,8 @@ func EventIDFromContext(ctx context.Context) uuid.UUID {
 	return uuid.Nil
 }
 
-// VersionFromContext returns the Version or 0 if not present
+// VersionFromContext returns the stream version set by [WithEnvelope], or 0
+// if ctx carries none.
 func VersionFromContext(ctx context.Context) uint64 {
 	if v := ctx.Value(versionKey); v != nil {
 		if ver, ok := v.(uint64); ok {
@@ -73,7 +79,8 @@ func VersionFromContext(ctx context.Context) uint64 {
 	return 0
 }
 
-// VersionFromContext returns the Version or 0 if not present
+// GlobalVersionFromContext returns the global version set by
+// [WithEnvelope], or 0 if ctx carries none.
 func GlobalVersionFromContext(ctx context.Context) uint64 {
 	if v := ctx.Value(globalVersionKey); v != nil {
 		if ver, ok := v.(uint64); ok {
@@ -83,7 +90,8 @@ func GlobalVersionFromContext(ctx context.Context) uint64 {
 	return 0
 }
 
-// OccurredAtFromContext returns OccurredAt or zero time if not present
+// OccurredAtFromContext returns the occurred-at time set by [WithEnvelope],
+// or the zero [time.Time] if ctx carries none.
 func OccurredAtFromContext(ctx context.Context) time.Time {
 	if v := ctx.Value(occurredAtKey); v != nil {
 		if t, ok := v.(time.Time); ok {
@@ -93,7 +101,8 @@ func OccurredAtFromContext(ctx context.Context) time.Time {
 	return time.Time{}
 }
 
-// MetadataFromContext returns Metadata or nil if not present
+// MetadataFromContext returns the metadata set by [WithEnvelope], or nil if
+// ctx carries none.
 func MetadataFromContext(ctx context.Context) map[string]any {
 	if v := ctx.Value(metadataKey); v != nil {
 		if md, ok := v.(map[string]any); ok {
@@ -103,12 +112,16 @@ func MetadataFromContext(ctx context.Context) map[string]any {
 	return nil
 }
 
+// WithCausation returns a copy of ctx carrying causation, the identifier of
+// whatever caused the work now happening under ctx — for example, a
+// command's type name — for handlers to attach to events or log entries.
 func WithCausation(ctx context.Context, causation string) context.Context {
 	ctx = context.WithValue(ctx, causationIDKey, causation)
 	return ctx
 }
 
-// CausationFromContext returns Metadata or nil if not present
+// CausationFromContext returns the causation ID set by [WithCausation], or
+// "" if ctx carries none.
 func CausationFromContext(ctx context.Context) string {
 	if v := ctx.Value(causationIDKey); v != nil {
 		if causation, ok := v.(string); ok {

--- a/errors.go
+++ b/errors.go
@@ -6,18 +6,43 @@ import (
 )
 
 var (
-	ErrStreamNotFound       = errors.New("stream not found")
-	ErrStreamExists         = errors.New("stream already exists")
-	ErrInvalidEventBatch    = errors.New("invalid event batch")
-	ErrHandlerNotFound      = errors.New("handler not registered")
-	ErrInvalidRevision      = errors.New("invalid revision")
+	// ErrStreamNotFound is returned by an [EventStore] when [StreamExists] is
+	// required for a stream that does not exist.
+	ErrStreamNotFound = errors.New("stream not found")
+	// ErrStreamExists is returned by an [EventStore] when [NoStream] is
+	// required for a stream that already exists.
+	ErrStreamExists = errors.New("stream already exists")
+	// ErrInvalidEventBatch is returned by [EventStore.Save] when the given
+	// envelopes do not all share the same stream ID.
+	ErrInvalidEventBatch = errors.New("invalid event batch")
+	// ErrHandlerNotFound is returned by a [QueryBus] when no [QueryHandler]
+	// is registered for a query's type.
+	ErrHandlerNotFound = errors.New("handler not registered")
+	// ErrInvalidRevision is returned by an [EventStore] when given a
+	// [StreamState] implementation it does not support.
+	ErrInvalidRevision = errors.New("invalid revision")
+	// ErrHandlerNotRegistered is returned by a [CommandBus] when no
+	// [CommandHandler] is registered for a command's type.
 	ErrHandlerNotRegistered = errors.New("no handler registered for type")
-	ErrDuplicateHandler     = errors.New("duplicate handler registered ")
-	ErrHandlerPanicked      = errors.New("handler panicked when handling command")
-	ErrCommandBusClosed     = errors.New("command bus is closed")
-	ErrEventNotRegistered   = errors.New("event not registered")
+	// ErrDuplicateHandler is returned or panicked with when registering a
+	// second handler for a command or event type that already has one, by
+	// [CommandBus.Register], [EventBus.Subscribe] implementations, and
+	// [QueryBus] registration.
+	ErrDuplicateHandler = errors.New("duplicate handler registered ")
+	// ErrHandlerPanicked is joined into the error a [CommandBus] returns
+	// when a [CommandHandler] panics instead of returning an error.
+	ErrHandlerPanicked = errors.New("handler panicked when handling command")
+	// ErrCommandBusClosed is wrapped into the error a [CommandBus] returns
+	// when Dispatch is called after Stop.
+	ErrCommandBusClosed = errors.New("command bus is closed")
+	// ErrEventNotRegistered is returned by [NewEventByName] when no event
+	// type is registered under the given name.
+	ErrEventNotRegistered = errors.New("event not registered")
 )
 
+// StreamRevisionConflictError is returned by an [EventStore] when a save is
+// made against a [Revision] that no longer matches the stream's actual
+// revision — an optimistic-concurrency conflict.
 type StreamRevisionConflictError struct {
 	Stream           string
 	ExpectedRevision StreamState
@@ -26,11 +51,12 @@ type StreamRevisionConflictError struct {
 
 func (s StreamRevisionConflictError) Error() string {
 	return fmt.Sprintf("concurrency conflict on stream %q: (expected version %d, actual %d)",
-		s.Stream, s.ExpectedRevision, s.ActualRevision,
+		s.Stream, s.ExpectedRevision.ToRawInt64(), s.ActualRevision.ToRawInt64(),
 	)
 }
 
-// ErrSkippedEvent is returned when a handler cannot handle the event type.
+// ErrSkippedEvent is returned when an [EventHandler] declines to process an
+// [Event] because it is not the type the handler expects.
 type ErrSkippedEvent struct {
 	Event Event
 }
@@ -39,9 +65,9 @@ func (e ErrSkippedEvent) Error() string {
 	return fmt.Sprintf("skipped event of type %T", e.Event)
 }
 
-// ErrBusinessRuleViolation is returned when a command violates a business rule.
-// Use this to signal domain-level rejections that are expected and recoverable,
-// as opposed to infrastructure or persistence errors.
+// ErrBusinessRuleViolation wraps an error returned when a [Command] violates
+// a business rule. Use it to signal expected, recoverable domain-level
+// rejections, as opposed to infrastructure or persistence errors.
 type ErrBusinessRuleViolation struct {
 	Err error
 }

--- a/event.go
+++ b/event.go
@@ -6,18 +6,34 @@ import (
 	"github.com/google/uuid"
 )
 
-// Event is a domain event describing a change that has happened to an aggregate.
+// Event is a domain event describing a change that has already happened to
+// an aggregate.
 type Event interface {
+	// AggregateID returns the ID of the aggregate this event happened to.
 	AggregateID() string
+	// EventType returns the name under which this event's concrete type is
+	// registered; see [RegisterEvent].
 	EventType() string
 }
 
+// Envelope wraps an [Event] with the metadata an [EventStore] or [EventBus]
+// needs to persist, order, and route it.
 type Envelope struct {
-	EventID       uuid.UUID
-	StreamID      string
-	Metadata      map[string]any
-	Event         Event
-	Version       uint64
+	// EventID uniquely identifies this occurrence of the event.
+	EventID uuid.UUID
+	// StreamID is the ID of the stream the event was appended to, typically
+	// the aggregate's ID.
+	StreamID string
+	// Metadata carries caller-supplied, out-of-band information about the
+	// event, such as correlation IDs or the acting user.
+	Metadata map[string]any
+	// Event is the wrapped domain event.
+	Event Event
+	// Version is the event's position within its own stream, starting at 1.
+	Version uint64
+	// GlobalVersion is the event's position across all streams, used to
+	// resume a global subscription from a specific point.
 	GlobalVersion uint64
-	OccurredAt    time.Time
+	// OccurredAt is when the event was appended to the store.
+	OccurredAt time.Time
 }

--- a/event_bus.go
+++ b/event_bus.go
@@ -2,23 +2,32 @@ package eventsourcing
 
 import "context"
 
+// SubscriberOption configures a subscription registered via
+// [EventBus.Subscribe]. Available options are implementation-specific; see,
+// for example, the memory package's WithFilterEvents.
 type SubscriberOption func(cfg any)
 
-// EventBus is an EventHandler that distributes published events to all matching
-// handlers that are registered, but only one of each type will handle the event.
+// EventBus lets [EventHandler]s subscribe to receive events as they occur,
+// fanning each event out to every matching subscriber. How events are fed
+// into the bus (typically as a side effect of an [EventStore] save) is
+// left to the implementation.
 type EventBus interface {
-	// Subscribe adds a handler for an event. Returns an error if either the
-	// matcher or handler is nil, the handler is already added or there was some
-	// other problem adding the handler (for networked handlers for example).
+	// Subscribe registers handler under name to receive events, optionally
+	// narrowed by options. It returns an error if handler is nil, name is
+	// already registered, or the subscription otherwise could not be added
+	// (for example, for a networked implementation).
 	Subscribe(ctx context.Context, name string, handler EventHandler, options ...SubscriberOption) error
 
-	// Use adds one or more middlewares to the EventBus.
-	// Must be called before Subscribe; middleware is applied to each handler at subscribe time.
+	// Use adds middlewares to be applied to every handler registered via
+	// Subscribe afterward. It must be called before Subscribe, since
+	// middleware is applied at subscribe time.
 	Use(middlewares ...EventHandlerMiddleware)
 
-	// Errors returns an error channel where async handling errors are sent.
+	// Errors returns a channel on which asynchronous handling errors are
+	// delivered.
 	Errors() <-chan error
 
-	// Close closes the EventBus and waits for all handlers to finish.
+	// Close shuts down the EventBus and waits for all handlers to finish
+	// processing events already delivered to them.
 	Close() error
 }

--- a/event_handler.go
+++ b/event_handler.go
@@ -6,32 +6,17 @@ import (
 	"sort"
 )
 
-// EventHandler represents a generic event handler that can handle an Event.
+// EventHandler processes events delivered by an [EventBus] or
+// [EventGroupProcessor].
 type EventHandler interface {
-	// Handle processes the given Event within the provided context.
+	// Handle processes event within ctx.
 	Handle(ctx context.Context, event Event) error
 }
 
-// NewEventHandlerFunc creates an EventHandler from a plain function.
-//
-// This is a helper for quickly creating an EventHandler without defining
-// a separate struct. It wraps the provided function and implements
-// the EventHandler interface, allowing it to be used wherever an
-// EventHandler is required, such as in an EventHandlerGroup.
-//
-// Parameters:
-//   - fn: A function with signature func(ctx context.Context, ev Event) error.
-//     This function will be called whenever the EventHandler receives an event.
-//
-// Returns:
-//   - EventHandler: an implementation of the EventHandler interface
-//     that delegates event handling to the provided function.
-//
-// Behavior Details:
-//   - The provided function is called for every event passed to the EventHandler.
-//   - There is no type-checking or filtering: the handler will receive all events
-//     that it is invoked with. If you need type safety, use OnEvent[T] instead.
-//   - Any error returned by the function is propagated directly to the caller.
+// NewEventHandlerFunc returns fn as an [EventHandler], for quickly wrapping
+// a function without defining a separate type. fn is called for every event
+// it is invoked with, unfiltered by type; use [OnEvent] instead if you only
+// want to handle one concrete event type.
 //
 // Example Usage:
 //
@@ -54,11 +39,14 @@ func (h eventHandlerFunc) Handle(ctx context.Context, event Event) error {
 	return h(ctx, event)
 }
 
-// typedEventHandler is a strongly typed event handler for a specific Event type T.
+// typedEventHandler is an [EventHandler] for one specific Event type T,
+// keyed for [EventGroupProcessor] routing by T's package-qualified type
+// name (the same %T-derived form [EventNamesFor] keys its internal
+// type-to-name lookup by).
 type typedEventHandler[T Event] func(ctx context.Context, ev T) error
 
-// EventName returns the name of the event type T.
-// It is used internally by eventGroupProcessor for routing.
+// EventName returns T's package-qualified type name, used as the routing
+// key by [EventGroupProcessor].
 func (h typedEventHandler[T]) EventName() string {
 	var zero T
 	return fmt.Sprintf("%T", zero)
@@ -70,37 +58,20 @@ func (h typedEventHandler[T]) EventInstance() Event {
 	return zero
 }
 
-// Handle processes the event if it matches the type T.
-// Returns ErrSkippedEvent if the event is of the wrong type.
+// Handle calls h with event if it has type T, or returns [ErrSkippedEvent]
+// otherwise.
 func (h typedEventHandler[T]) Handle(ctx context.Context, event Event) error {
 	ev, ok := event.(T)
 	if !ok {
-		// Return sentinel error instead of voiding it
 		return &ErrSkippedEvent{Event: event}
 	}
 	return h(ctx, ev)
 }
 
-// OnEvent creates a strongly-typed EventHandler for a specific event type.
-//
-// It provides a reusable pattern for handling events in a type-safe manner
-// by performing the following steps:
-//  1. Wraps a user-provided function `fn(ctx, ev T)` into a typed handler.
-//  2. Associates the handler with the type name of T for internal routing.
-//  3. Returns an EventHandler that can be registered in an eventGroupProcessor.
-//
-// Parameters:
-//   - fn: A function with signature func(ctx context.Context, ev T) error,
-//     where T implements the Event interface.
-//
-// Returns:
-//   - EventHandler: a strongly-typed handler for events of type T.
-//
-// Behavior Details:
-//   - When called via eventGroupProcessor.Handle, the handler will only receive
-//     events of type T. If a different event type is passed, it returns
-//     ErrSkippedEvent.
-//   - EventName() internally derives the type name of T using TypeName[T].
+// OnEvent returns fn as an [EventHandler] that only processes events of
+// type T, returning [ErrSkippedEvent] for any other type. It is meant to be
+// registered with an [EventGroupProcessor], which uses T's type name to
+// route only matching events to it.
 //
 // Example Usage:
 //
@@ -114,31 +85,17 @@ func OnEvent[T Event](fn func(ctx context.Context, ev T) error) EventHandler {
 	return typedEventHandler[T](fn)
 }
 
-// EventGroupProcessor is a collection of typed event handlers.
-// It routes incoming events to the correct handler based on event type.
+// EventGroupProcessor routes each incoming event to the [EventHandler]
+// registered for its concrete type, typically one built with [OnEvent].
 type EventGroupProcessor struct {
 	handlers map[string]EventHandler // key = EventName()
 }
 
-// NewEventGroupProcessor creates a group of typed event handlers.
-//
-// It provides a reusable pattern for routing events to the correct handler
-// by performing the following steps:
-//  1. Accepts a list of typed EventHandler instances (created via OnEvent).
-//  2. Validates that all handlers implement EventName().
-//  3. Builds an internal map from EventName() to EventHandler for fast routing.
-//  4. Panics if duplicate handlers are provided for the same event type.
-//
-// Parameters:
-//   - handlers: A variadic list of typed EventHandler instances.
-//
-// Returns:
-//   - *eventGroupProcessor: a processor that routes events to the appropriate handler.
-//
-// Behavior Details:
-//   - Events are dispatched based on the EventName() returned by the handler.
-//   - If no handler exists for an event, Handle returns ErrSkippedEvent.
-//   - StreamFilter() returns the sorted list of event names handled by the group.
+// NewEventGroupProcessor builds an [EventGroupProcessor] from handlers,
+// which must each implement an internal EventName() string method — as the
+// handlers returned by [OnEvent] do — used as the routing key. It panics if
+// a handler doesn't implement that method, or if two handlers report the
+// same EventName().
 //
 // Example Usage:
 //
@@ -170,8 +127,8 @@ func NewEventGroupProcessor(handlers ...EventHandler) *EventGroupProcessor {
 	}
 }
 
-// Handle routes the given event to the correct typed handler.
-// Returns ErrSkippedEvent if no handler exists for the event type.
+// Handle routes ev to the handler registered for its concrete type, or
+// returns [ErrSkippedEvent] if none is registered.
 func (p *EventGroupProcessor) Handle(ctx context.Context, ev Event) error {
 	name := fmt.Sprintf("%T", ev)
 	h, ok := p.handlers[name]
@@ -182,8 +139,10 @@ func (p *EventGroupProcessor) Handle(ctx context.Context, ev Event) error {
 	return h.Handle(ctx, ev)
 }
 
-// StreamFilter returns a sorted list of all event names handled by this group.
-// Useful for subscribing to streams or listing registered handlers.
+// StreamFilter returns the sorted, registered names (see [EventNamesFor])
+// of every event type this group has a handler for — useful, for example,
+// as the filter passed to [EventBus.Subscribe] via a filtering
+// [SubscriberOption].
 func (p *EventGroupProcessor) StreamFilter() []string {
 	out := make([]string, 0, len(p.handlers))
 	for _, h := range p.handlers {

--- a/event_registry.go
+++ b/event_registry.go
@@ -16,22 +16,11 @@ var (
 	// registryMu protects access to the registry for concurrent operations.
 	registryMu sync.RWMutex
 
-	// RegisterEventByType registers a new Event type using its default type name.
-	//
-	// It provides a reusable pattern for dynamically creating new event instances
-	// by string name. Registration performs the following steps:
-	//   1. Calls the provided factory function to obtain an instance of the event.
-	//   2. Retrieves the type name using EventType().
-	//   3. Registers the factory in the registry keyed by the type name.
-	//
-	// Parameters:
-	//   - fn: A factory function of type func() Event that returns a new instance
-	//     of the event. The factory must not return nil.
-	//
-	// Panics:
-	//   - If the factory function is nil.
-	//   - If the factory returns nil.
-	//   - If an event with the same type name is already registered.
+	// RegisterEventByType registers fn under the type name of the [Event] it
+	// returns, i.e. fn().EventType(). Use this instead of [RegisterEvent]
+	// when you need explicit control over the factory, for example to
+	// inject constructor arguments. It panics if fn is nil, if fn() returns
+	// nil, or if an event is already registered under that name.
 	//
 	// Example Usage:
 	//   RegisterEventByType(func() Event { return &InventoryChanged{} })
@@ -39,20 +28,11 @@ var (
 		registerEventNameDefault(fn().EventType(), fn)
 	}
 
-	// RegisterEventByName registers a new Event type under a custom name.
-	//
-	// This is similar to RegisterEventByType, but allows using a name
-	// that is independent of EventType(). The provided factory function
-	// must return a new instance of the event type each time it is called.
-	//
-	// Parameters:
-	//   - name: The unique name to register the event under.
-	//   - fn: Factory function of type func() Event that returns a new instance.
-	//
-	// Panics:
-	//   - If fn is nil.
-	//   - If fn returns nil.
-	//   - If the name is already registered.
+	// RegisterEventByName registers fn under name, independently of the
+	// event's own EventType() — useful when the name a store has events
+	// persisted under no longer matches the current type name, for example
+	// after a rename. As with [RegisterEventByType], it panics if fn is nil,
+	// if fn() returns nil, or if name is already registered.
 	//
 	// Example Usage:
 	//   RegisterEventByName("CustomEventName", func() Event { return &InventoryChanged{} })
@@ -60,26 +40,17 @@ var (
 		registerEventNameDefault(name, fn)
 	}
 
-	// NewEventByName creates a new instance of a registered Event by its name.
-	//
-	// This function allows dynamic instantiation of events using their string name.
-	// It performs the following steps:
-	//   1. Looks up the factory function in the registry.
-	//   2. Calls the factory to create a new instance.
-	//
-	// Parameters:
-	//   - name: The name of the event to create.
-	//
-	// Returns:
-	//   - Event: A new instance of the registered event.
-	//   - error: Non-nil if the event name is not registered or the factory
-	//     returned nil.
+	// NewEventByName returns a new instance of the [Event] registered under
+	// name, or a non-nil [ErrEventNotRegistered] if no event is registered
+	// under that name.
 	//
 	// Example Usage:
 	//   ev, err := NewEventByName("InventoryChanged")
 	NewEventByName func(name string) (Event, error) = newEventByNameDefault
 
-	// EventNamesFor returns the registered names for a given Event type.
+	// EventNamesFor returns every name event's concrete type is registered
+	// under, regardless of which [RegisterEvent]/[RegisterEventByType]/
+	// [RegisterEventByName] call added each one.
 	EventNamesFor func(event Event) []string = func(event Event) []string {
 		registryMu.RLock()
 		defer registryMu.RUnlock()
@@ -88,34 +59,24 @@ var (
 	}
 )
 
-// eventPtr constrains PT to be a pointer to T that also implements Event.
-//
-// It lets RegisterEvent mint a genuinely new instance via new(T) for each
-// registration, the same way InitialState[T] lets a caller supply a factory
-// for T — except here the factory is derived from the type itself instead
-// of reflect, so no runtime type inspection is needed.
+// eventPtr constrains PT to a pointer to T that implements [Event], letting
+// [RegisterEvent] recover T from PT and mint new(T) itself, rather than
+// storing and replaying the single value the caller passed in.
 type eventPtr[T any] interface {
 	*T
 	Event
 }
 
-// RegisterEvent registers a new Event type using its default type name.
-//
-// Unlike RegisterEventByType and RegisterEventByName, RegisterEvent does not
-// take a factory function. Instead it infers the concrete type T from the
-// pointer passed in and builds its own factory that returns new(T) on every
-// call, so each registration is guaranteed a fresh instance without reflect
-// and without the caller having to write out a closure.
-//
-// Parameters:
-//   - _: A pointer to a zero-value instance of the event, used only to infer
-//     its concrete type. The value itself is discarded.
-//
-// Panics:
-//   - If an event with the same type name is already registered.
+// RegisterEvent registers the concrete event type T — inferred from the
+// pointer passed in, whose value is otherwise discarded — under its default
+// [Event.EventType] name. Each later [NewEventByName] call for that name
+// returns a fresh new(T), so unlike a hand-written closure over a single
+// instance, concurrent or repeated decodes never alias the same value. It
+// panics if an event is already registered under that name.
 //
 // Example Usage:
-//   RegisterEvent(&OrderCreated{})
+//
+//	RegisterEvent(&OrderCreated{})
 func RegisterEvent[T any, PT eventPtr[T]](_ PT) {
 	RegisterEventByType(func() Event {
 		return PT(new(T))

--- a/eventbus/file/eventbus.go
+++ b/eventbus/file/eventbus.go
@@ -16,6 +16,9 @@ import (
 )
 
 // ---- Subscriber ----
+
+// subscriber is a single registered handler and the event-type filter and
+// per-subscriber directory it watches for new event files.
 type subscriber struct {
 	name    string
 	handler eventsourcing.EventHandler
@@ -25,11 +28,16 @@ type subscriber struct {
 
 var _ eventsourcing.EventBus = (*FileEventBus)(nil)
 
+// fileSubscriberOptions accumulates the [eventsourcing.SubscriberOption]
+// values passed to Subscribe.
 type fileSubscriberOptions struct {
 	filter map[string]struct{}
 }
 
-// WithFilterEvents returns a SubscriberOption that limits delivery to the given event types.
+// WithFilterEvents returns an [eventsourcing.SubscriberOption] that limits
+// delivery to events whose type is one of events. Without this option, a
+// subscriber receives every dispatched event. It has no effect if applied
+// to a bus other than this package's [FileEventBus].
 func WithFilterEvents(events ...string) eventsourcing.SubscriberOption {
 	return func(cfg any) {
 		if c, ok := cfg.(*fileSubscriberOptions); ok {
@@ -41,6 +49,18 @@ func WithFilterEvents(events ...string) eventsourcing.SubscriberOption {
 }
 
 // ---- File-based EventBus ----
+
+// FileEventBus is a file-backed [eventsourcing.EventBus]. Each dispatched
+// event is written as one JSON file per subscriber directory; a subscriber
+// watches its directory with fsnotify and deletes each file once its
+// handler successfully processes it. Existing files are replayed on
+// Subscribe, so a subscriber recovers events that arrived while it (or the
+// process) was not running.
+//
+// If a handler returns an error, its file is left in place rather than
+// deleted, and reprocessing happens on the next filesystem event for that
+// directory or the next time the subscriber is started — there is no
+// active retry loop in between.
 type FileEventBus struct {
 	mu          sync.RWMutex
 	subs        map[string]*subscriber
@@ -51,7 +71,9 @@ type FileEventBus struct {
 	middlewares []eventsourcing.EventHandlerMiddleware
 }
 
-// NewFileEventBus constructs the bus in root dir.
+// NewFileEventBus constructs a [FileEventBus] backed by root, creating the
+// directory (and any missing parents) if it does not already exist. It
+// returns an error if the directory cannot be created.
 func NewFileEventBus(root string) (*FileEventBus, error) {
 	if err := os.MkdirAll(root, 0o755); err != nil {
 		return nil, err
@@ -64,11 +86,21 @@ func NewFileEventBus(root string) (*FileEventBus, error) {
 	}, nil
 }
 
+// Use adds middlewares that wrap every handler registered afterward via
+// Subscribe. As required by [eventsourcing.EventBus], it must be called
+// before Subscribe: middlewares added after a given subscriber is
+// registered do not apply to that subscriber.
 func (b *FileEventBus) Use(middlewares ...eventsourcing.EventHandlerMiddleware) {
 	b.middlewares = append(b.middlewares, middlewares...)
 }
 
-// Subscribe registers a subscriber with optional event filters.
+// Subscribe registers handler under name, creating a dedicated directory
+// for it under the bus's root, replaying any event files already present,
+// and then watching for new ones. By default a subscriber receives every
+// event; pass [WithFilterEvents] to restrict delivery to specific event
+// types. It returns an error if handler is nil, the bus is already closed,
+// name is already registered, or the subscriber directory cannot be
+// created. The subscription is removed automatically when ctx is canceled.
 func (b *FileEventBus) Subscribe(
 	ctx context.Context,
 	name string,
@@ -127,11 +159,19 @@ func (b *FileEventBus) Subscribe(
 	return nil
 }
 
+// Errors returns the channel on which asynchronous handler errors are
+// delivered, as required by [eventsourcing.EventBus].
 func (b *FileEventBus) Errors() <-chan error {
 	return b.errs
 }
 
-// Dispatch writes the event to all matching subscriber directories
+// Dispatch writes env as a new file in the directory of every subscriber
+// whose filter matches it (see [WithFilterEvents]), or of every subscriber
+// if none configured a filter; each subscriber's own goroutine then reads,
+// handles, and deletes the file asynchronously. Dispatch returns an error
+// only if env cannot be marshaled to JSON; a write failure for an
+// individual subscriber's directory is skipped silently and not reported
+// to the caller. Dispatch is a no-op once the bus has been closed.
 func (b *FileEventBus) Dispatch(env *eventsourcing.Envelope) error {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -166,7 +206,9 @@ func (b *FileEventBus) Dispatch(env *eventsourcing.Envelope) error {
 	return nil
 }
 
-// runSubscriber watches the subscriber directory for new events
+// runSubscriber first replays any event files already present in dir (crash
+// recovery), then watches dir with fsnotify and processes each new file as
+// it appears, until ctx is canceled.
 func (b *FileEventBus) runSubscriber(ctx context.Context, s *subscriber, dir string) {
 	defer b.wg.Done()
 
@@ -214,7 +256,9 @@ func (b *FileEventBus) runSubscriber(ctx context.Context, s *subscriber, dir str
 	}
 }
 
-// processFile reads and handles a single event file, then deletes on success
+// processFile reads and decodes the envelope at path, invokes s.handler,
+// and deletes the file only if the handler returns nil. On any error the
+// file is left in place for the next event or subscriber restart to retry.
 func (b *FileEventBus) processFile(ctx context.Context, s *subscriber, path string) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -233,7 +277,8 @@ func (b *FileEventBus) processFile(ctx context.Context, s *subscriber, path stri
 	_ = os.Remove(path)
 }
 
-// removeSubscriber cancels and removes a subscriber
+// removeSubscriber cancels and unregisters the named subscriber. It is a
+// no-op if name is not registered.
 func (b *FileEventBus) removeSubscriber(name string) {
 	b.mu.Lock()
 	s, ok := b.subs[name]
@@ -247,7 +292,14 @@ func (b *FileEventBus) removeSubscriber(name string) {
 	}
 }
 
-// Close shuts down the bus and waits for workers.
+// Close cancels every subscriber and waits for their worker goroutines to
+// finish before closing the Errors channel.
+//
+// TODO: unlike the memory, postgres, and kurrentdb EventBus
+// implementations, Close does not check b.closed before proceeding, so
+// calling Close a second time will attempt to close(b.errs) again and
+// panic. Either guard this like the sibling implementations or document
+// that Close here must only be called once.
 func (b *FileEventBus) Close() error {
 	b.mu.Lock()
 	b.closed = true

--- a/eventbus/kurrentdb/eventbus.go
+++ b/eventbus/kurrentdb/eventbus.go
@@ -14,6 +14,12 @@ import (
 	cqrs "github.com/terraskye/eventsourcing"
 )
 
+// EventBus is a KurrentDB-backed [cqrs.EventBus]. Each subscriber is backed
+// by a persistent subscription to $all: Subscribe creates the subscription
+// if it does not already exist and then consumes it with automatic
+// reconnect and retry. Delivery is at-least-once: an event is acknowledged
+// to KurrentDB only after the handler returns nil or [cqrs.ErrSkippedEvent],
+// so a handler error leaves the event pending for redelivery.
 type EventBus struct {
 	db          *kurrentdb.Client
 	subs        map[string]*subscriber
@@ -25,6 +31,8 @@ type EventBus struct {
 	middlewares []cqrs.EventHandlerMiddleware
 }
 
+// subscriber is a single registered handler together with the persistent
+// subscription options it was created with.
 type subscriber struct {
 	name    string
 	opt     kurrentdb.SubscribeToPersistentSubscriptionOptions
@@ -33,7 +41,13 @@ type subscriber struct {
 	cancel  context.CancelFunc
 }
 
-// NewEventBus creates a KurrentDB-backed event bus
+// NewEventBus creates a KurrentDB-backed [EventBus] using db as the
+// underlying client.
+//
+// TODO: the buffer parameter is stored but never read anywhere in this
+// package — there is no internal channel it sizes. Either wire it up (e.g.
+// to size a delivery buffer) or remove it; as written it is dead
+// configuration that misleads callers into thinking it affects behavior.
 func NewEventBus(db *kurrentdb.Client, buffer uint64) *EventBus {
 	return &EventBus{
 		db:     db,
@@ -43,10 +57,23 @@ func NewEventBus(db *kurrentdb.Client, buffer uint64) *EventBus {
 	}
 }
 
+// Use adds middlewares that wrap every handler registered afterward via
+// Subscribe. As required by [cqrs.EventBus], it must be called before
+// Subscribe: middlewares added after a given subscriber is registered do
+// not apply to that subscriber.
 func (b *EventBus) Use(middlewares ...cqrs.EventHandlerMiddleware) {
 	b.middlewares = append(b.middlewares, middlewares...)
 }
 
+// Subscribe registers handler under name as the consumer of a persistent
+// subscription to $all called name, creating that subscription first if it
+// does not already exist (see EnsurePersistentSubscription). Options such
+// as WithStartAtZero, WithStartAt, WithFilterEvents, and WithFilterStream
+// configure the subscription at creation time only; they have no effect on
+// a subscription that already exists in KurrentDB. It returns an error if
+// handler is nil, the bus is already closed, name is already registered, or
+// the subscription could not be ensured. The subscription is removed from
+// the bus automatically when ctx is canceled.
 func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.EventHandler, opts ...cqrs.SubscriberOption) error {
 	if handler == nil {
 		return errors.New("filter and handler cannot be nil")
@@ -99,6 +126,18 @@ func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.Even
 	return nil
 }
 
+// EnsurePersistentSubscription creates the persistent subscription to $all
+// called name, using opt, if it does not already exist. If a subscription
+// by that name already exists, it is left untouched.
+//
+// TODO: if GetPersistentSubscriptionInfoToAll fails with anything other
+// than kurrentdb.ErrorCodeResourceNotFound — including errors that aren't a
+// *kurrentdb.Error at all, e.g. a network failure — this function silently
+// returns nil instead of propagating the error or creating the
+// subscription. Subscribe then proceeds as if the subscription were ready,
+// so the real failure only surfaces later (if at all) as an async error
+// from the persistent-subscription stream. Consider returning err in the
+// non-not-found cases instead of swallowing it.
 func (b *EventBus) EnsurePersistentSubscription(ctx context.Context, name string, opt kurrentdb.PersistentAllSubscriptionOptions) error {
 
 	var kurrentErr *kurrentdb.Error
@@ -124,6 +163,12 @@ func (b *EventBus) EnsurePersistentSubscription(ctx context.Context, name string
 	return nil
 }
 
+// runSubscriber runs s's persistent subscription with exponential-backoff
+// reconnect on failure, up to 100 attempts. If the subscription still
+// cannot be established after those attempts, it sends a final error on
+// Errors() and returns, permanently stopping delivery for s; s's name
+// remains registered until its context is canceled or the bus is closed, so
+// it cannot be re-subscribed under the same name in the meantime.
 func (b *EventBus) runSubscriber(ctx context.Context, s *subscriber) {
 	defer b.wg.Done()
 
@@ -155,6 +200,13 @@ func (b *EventBus) runSubscriber(ctx context.Context, s *subscriber) {
 	}
 }
 
+// runSubscription reads from s's persistent subscription until ctx is
+// canceled or the subscription is dropped, decoding each event, dispatching
+// it to s.handler, and acknowledging it to KurrentDB unless the handler
+// returns an error other than [cqrs.ErrSkippedEvent] (in which case it is
+// left unacknowledged for redelivery). It returns a non-nil error whenever
+// the subscription ends for a reason other than ctx being canceled, so the
+// caller can decide to reconnect.
 func (b *EventBus) runSubscription(ctx context.Context, s *subscriber) error {
 	stream, err := b.db.SubscribeToPersistentSubscriptionToAll(ctx, s.name, s.opt)
 	if err != nil {
@@ -249,6 +301,8 @@ func (b *EventBus) runSubscription(ctx context.Context, s *subscriber) error {
 	}
 }
 
+// removeSubscriber cancels and unregisters the named subscriber. It is a
+// no-op if name is not registered.
 func (b *EventBus) removeSubscriber(name string) {
 	b.mu.Lock()
 	sub, ok := b.subs[name]
@@ -259,10 +313,15 @@ func (b *EventBus) removeSubscriber(name string) {
 	b.mu.Unlock()
 }
 
+// Errors returns the channel on which asynchronous handler and subscription
+// errors are delivered, as required by [cqrs.EventBus].
 func (b *EventBus) Errors() <-chan error {
 	return b.errs
 }
 
+// Close cancels every subscriber and waits for their worker goroutines to
+// finish before closing the Errors channel. Calling Close more than once is
+// a no-op.
 func (b *EventBus) Close() error {
 	b.mu.Lock()
 	if b.closed {
@@ -282,6 +341,10 @@ func (b *EventBus) Close() error {
 	return nil
 }
 
+// WithStartAtZero returns a [cqrs.SubscriberOption] that starts a newly
+// created persistent subscription from the beginning of $all. It has no
+// effect on a subscription that already exists in KurrentDB, and it panics
+// if applied to a bus other than this package's [EventBus].
 func WithStartAtZero() cqrs.SubscriberOption {
 	return func(cfg any) {
 		opts, ok := cfg.(*kurrentdb.PersistentAllSubscriptionOptions)
@@ -292,6 +355,10 @@ func WithStartAtZero() cqrs.SubscriberOption {
 	}
 }
 
+// WithStartAt returns a [cqrs.SubscriberOption] that starts a newly created
+// persistent subscription from the given commit/prepare position in $all.
+// It has no effect on a subscription that already exists in KurrentDB, and
+// it panics if applied to a bus other than this package's [EventBus].
 func WithStartAt(revision uint64) cqrs.SubscriberOption {
 	return func(cfg any) {
 		opts, ok := cfg.(*kurrentdb.PersistentAllSubscriptionOptions)
@@ -305,6 +372,15 @@ func WithStartAt(revision uint64) cqrs.SubscriberOption {
 	}
 }
 
+// WithFilterEvents returns a [cqrs.SubscriberOption] that configures a
+// newly created persistent subscription's server-side filter to include
+// only events whose KurrentDB event type is one of filteredEvents. It has
+// no effect on a subscription that already exists in KurrentDB. Since a
+// persistent subscription has a single filter, combine all desired names
+// into one call rather than calling this more than once: applying it
+// together with WithFilterStream, or applying either more than once, means
+// only the last one applied takes effect. It panics if applied to a bus
+// other than this package's [EventBus].
 func WithFilterEvents(filteredEvents []string) cqrs.SubscriberOption {
 	return func(cfg any) {
 		opts, ok := cfg.(*kurrentdb.PersistentAllSubscriptionOptions)
@@ -318,6 +394,12 @@ func WithFilterEvents(filteredEvents []string) cqrs.SubscriberOption {
 	}
 }
 
+// WithFilterStream returns a [cqrs.SubscriberOption] that configures a
+// newly created persistent subscription's server-side filter to include
+// only streams whose name starts with one of streams. It has no effect on
+// a subscription that already exists in KurrentDB, and — as with
+// WithFilterEvents — only the last filter option applied takes effect. It
+// panics if applied to a bus other than this package's [EventBus].
 func WithFilterStream(streams []string) cqrs.SubscriberOption {
 	return func(cfg any) {
 		opts, ok := cfg.(*kurrentdb.PersistentAllSubscriptionOptions)

--- a/eventbus/memory/eventbus.go
+++ b/eventbus/memory/eventbus.go
@@ -10,6 +10,9 @@ import (
 	cqrs "github.com/terraskye/eventsourcing"
 )
 
+// subscriber is a single registered handler and its per-handler delivery
+// state: an event-type filter and a buffered channel served by its own
+// worker goroutine.
 type subscriber struct {
 	name    string
 	handler cqrs.EventHandler
@@ -18,10 +21,15 @@ type subscriber struct {
 	cancel  context.CancelFunc
 }
 
+// filter holds the event-type allowlist configured via [WithFilterEvents].
 type filter struct {
 	events []string
 }
 
+// EventBus is an in-memory [cqrs.EventBus]. It delivers events to
+// subscribers within the process, using one buffered channel and worker
+// goroutine per subscriber; it does not persist events, so nothing is
+// replayed across process restarts.
 type EventBus struct {
 	mu          sync.RWMutex
 	subs        map[string]*subscriber
@@ -32,7 +40,9 @@ type EventBus struct {
 	middlewares []cqrs.EventHandlerMiddleware
 }
 
-// NewEventBus constructs a new bus with a given subscriber buffer size.
+// NewEventBus constructs an [EventBus] whose subscribers each buffer up to
+// bufferSize undelivered events. Once a subscriber's buffer is full,
+// Dispatch blocks until that subscriber's handler drains it.
 func NewEventBus(bufferSize int) *EventBus {
 	return &EventBus{
 		subs:       make(map[string]*subscriber),
@@ -41,11 +51,19 @@ func NewEventBus(bufferSize int) *EventBus {
 	}
 }
 
+// Use adds middlewares that wrap every handler registered afterward via
+// Subscribe. As required by [cqrs.EventBus], it must be called before
+// Subscribe: middlewares added after a given subscriber is registered do
+// not apply to that subscriber.
 func (b *EventBus) Use(middlewares ...cqrs.EventHandlerMiddleware) {
 	b.middlewares = append(b.middlewares, middlewares...)
 }
 
-// Subscribe registers a handler with a filter and name.
+// Subscribe registers handler under name to receive dispatched events. By
+// default a subscriber receives every event; pass [WithFilterEvents] to
+// restrict delivery to specific event types. It returns an error if handler
+// is nil, the bus is already closed, or name is already registered. The
+// subscription is removed automatically when ctx is canceled.
 func (b *EventBus) Subscribe(
 	ctx context.Context,
 	name string,
@@ -103,11 +121,15 @@ func (b *EventBus) Subscribe(
 	return nil
 }
 
+// Errors returns the channel on which asynchronous handler errors are
+// delivered, as required by [cqrs.EventBus].
 func (b *EventBus) Errors() <-chan error {
 	return b.errs
 }
 
-// Close shuts down the bus and waits for all workers.
+// Close cancels every subscriber and waits for their worker goroutines to
+// finish before closing the Errors channel. Calling Close more than once is
+// a no-op.
 func (b *EventBus) Close() error {
 	b.mu.Lock()
 	if b.closed {
@@ -133,7 +155,8 @@ func (b *EventBus) Close() error {
 	return nil
 }
 
-// runSubscriber processes events for a single handler.
+// runSubscriber delivers events from s.events to s.handler until ctx is
+// canceled or s.events is closed by Close or removeSubscriber.
 func (b *EventBus) runSubscriber(ctx context.Context, s *subscriber) {
 	defer b.wg.Done()
 
@@ -159,6 +182,8 @@ func (b *EventBus) runSubscriber(ctx context.Context, s *subscriber) {
 	}
 }
 
+// removeSubscriber cancels and unregisters the named subscriber. It is a
+// no-op if name is not registered.
 func (b *EventBus) removeSubscriber(name string) {
 	b.mu.Lock()
 	s, ok := b.subs[name]
@@ -173,7 +198,13 @@ func (b *EventBus) removeSubscriber(name string) {
 	close(s.events)
 }
 
-// Dispatch sends an event to all matching subscribers.
+// Dispatch delivers ev to every subscriber whose event-type filter matches
+// it (see [WithFilterEvents]), or to every subscriber if none configured a
+// filter. Each subscriber's handler sees events in the order Dispatch
+// delivered them, on that subscriber's own goroutine, but Dispatch itself
+// blocks until ev is queued for every matching subscriber — a subscriber
+// whose buffer is full therefore delays the caller until its handler
+// catches up. Dispatch is a no-op once the bus has been closed.
 func (b *EventBus) Dispatch(ev *cqrs.Envelope) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
@@ -191,6 +222,10 @@ func (b *EventBus) Dispatch(ev *cqrs.Envelope) {
 	}
 }
 
+// WithFilterEvents returns a [cqrs.SubscriberOption] that restricts delivery
+// to events whose [cqrs.Event.EventType] matches one of filteredEvents.
+// Without this option, a subscriber receives every dispatched event. It
+// panics if applied to a bus other than this package's [EventBus].
 func WithFilterEvents(filteredEvents []string) cqrs.SubscriberOption {
 	return func(cfg any) {
 		opts, ok := cfg.(*filter)

--- a/eventbus/postgres/eventbus.go
+++ b/eventbus/postgres/eventbus.go
@@ -26,9 +26,15 @@ const lockPoolMaxConns = 4
 // schema.sql sends on after every insert into events.
 const notifyChannel = "eventsourcing_events_inserted"
 
-// EventBus is a PostgreSQL-backed event bus that uses polling to deliver events
-// to subscribers. Each subscriber's position is persisted in the event_subscriptions
-// table, allowing subscriptions to resume after a restart.
+// EventBus is a PostgreSQL-backed [cqrs.EventBus] that delivers events by
+// polling, woken promptly by LISTEN/NOTIFY (see NewEventBus). Each
+// subscriber's position is persisted in the event_subscriptions table, so
+// subscriptions resume where they left off after a restart. Delivery is
+// at-least-once and in strict id order: if a handler returns an error other
+// than [cqrs.ErrSkippedEvent], that event and the rest of its batch are
+// retried on the next poll without advancing the subscriber's position (see
+// poll), so a handler that keeps failing blocks that subscriber
+// indefinitely.
 type EventBus struct {
 	pool         *pgxpool.Pool
 	lockPool     *pgxpool.Pool
@@ -44,6 +50,8 @@ type EventBus struct {
 	listenOnce   sync.Once
 }
 
+// subscriber is a single registered handler and its poll state: its
+// options, and a wake channel used to trigger an immediate poll on NOTIFY.
 type subscriber struct {
 	name    string
 	opts    subscriberOptions
@@ -52,12 +60,14 @@ type subscriber struct {
 	wake    chan struct{}
 }
 
+// subscriberOptions accumulates the [cqrs.SubscriberOption] values passed
+// to Subscribe.
 type subscriberOptions struct {
 	filterEvents []string
 	startFrom    *int64
 }
 
-// NewEventBus creates a PostgreSQL-backed EventBus.
+// NewEventBus creates a PostgreSQL-backed [EventBus].
 // pollInterval controls how frequently each subscriber polls for new events
 // as a fallback; in normal operation, LISTEN/NOTIFY wakes subscribers
 // immediately after a commit. A value of a few seconds is reasonable for
@@ -81,7 +91,7 @@ func NewEventBus(pool *pgxpool.Pool, pollInterval time.Duration) *EventBus {
 }
 
 // newLockPool creates a small pool dedicated to poll()'s subscription-locking
-// transaction
+// transaction.
 func newLockPool(pool *pgxpool.Pool) *pgxpool.Pool {
 	cfg := pool.Config().Copy()
 	cfg.MaxConns = lockPoolMaxConns
@@ -99,10 +109,22 @@ func newLockPool(pool *pgxpool.Pool) *pgxpool.Pool {
 	return lockPool
 }
 
+// Use adds middlewares that wrap every handler registered afterward via
+// Subscribe. As required by [cqrs.EventBus], it must be called before
+// Subscribe: middlewares added after a given subscriber is registered do
+// not apply to that subscriber.
 func (b *EventBus) Use(middlewares ...cqrs.EventHandlerMiddleware) {
 	b.middlewares = append(b.middlewares, middlewares...)
 }
 
+// Subscribe registers handler under name and starts polling for events on
+// its behalf, creating a persisted position record in event_subscriptions
+// if name has not been seen before (see ensureSubscription). By default a
+// subscriber receives every event; pass [WithFilterEvents] to restrict
+// delivery to specific event types, and [WithStartFrom] to control where a
+// brand-new subscription begins. It returns an error if handler is nil, the
+// bus is already closed, or name is already registered. The subscription is
+// removed automatically when ctx is canceled.
 func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.EventHandler, opts ...cqrs.SubscriberOption) error {
 	if handler == nil {
 		return errors.New("handler cannot be nil")
@@ -150,10 +172,15 @@ func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.Even
 	return nil
 }
 
+// Errors returns the channel on which asynchronous handler and polling
+// errors are delivered, as required by [cqrs.EventBus].
 func (b *EventBus) Errors() <-chan error {
 	return b.errs
 }
 
+// Close stops the LISTEN connection and every subscriber's polling, waits
+// for their goroutines to finish, and closes the Errors channel. Calling
+// Close more than once is a no-op.
 func (b *EventBus) Close() error {
 	b.mu.Lock()
 	if b.closed {
@@ -178,6 +205,8 @@ func (b *EventBus) Close() error {
 	return nil
 }
 
+// runSubscriber polls for s on b.pollInterval, or immediately whenever s.wake
+// is signaled by a NOTIFY, until ctx is canceled.
 func (b *EventBus) runSubscriber(ctx context.Context, s *subscriber) {
 	defer b.wg.Done()
 
@@ -225,7 +254,22 @@ func (b *EventBus) ensureSubscription(ctx context.Context, s *subscriber) error 
 	return err
 }
 
-// poll locks the subscription row so that only one instance processes events at a time.
+// poll locks the subscription row so that only one instance processes
+// events for s at a time, then reads events with id greater than the
+// stored position and delivers them to s.handler in id order.
+//
+// The scan only considers events already visible in a fresh MVCC snapshot,
+// filtering out rows whose inserting transaction is still in progress (via
+// pg_snapshot_xmin). This means a slow transaction that has already
+// allocated a lower id delays delivery of every higher id until it commits
+// or rolls back, which keeps poll from ever advancing past that id and
+// permanently skipping it once it does commit.
+//
+// If s.handler returns an error other than [cqrs.ErrSkippedEvent], poll
+// returns without committing, so the position is not advanced and the same
+// batch (including any events already handled successfully earlier in this
+// call) is retried on the next poll.
+//
 // The locking transaction runs on b.lockPool, not b.pool: it is held open for the
 // entire call, including every s.handler.Handle() invocation, and Handle() typically
 // needs its own connection from b.pool. Keeping the two pools separate avoids a
@@ -379,6 +423,8 @@ func sleepCtx(ctx context.Context, d time.Duration) bool {
 	}
 }
 
+// removeSubscriber cancels and unregisters the named subscriber. It is a
+// no-op if name is not registered.
 func (b *EventBus) removeSubscriber(name string) {
 	b.mu.Lock()
 	sub, ok := b.subs[name]
@@ -389,6 +435,8 @@ func (b *EventBus) removeSubscriber(name string) {
 	b.mu.Unlock()
 }
 
+// sendErr sends err on the Errors channel, dropping it if the channel's
+// buffer is full rather than blocking the caller.
 func (b *EventBus) sendErr(err error) {
 	select {
 	case b.errs <- err:
@@ -396,9 +444,11 @@ func (b *EventBus) sendErr(err error) {
 	}
 }
 
-// WithStartFrom sets the global event position from which a new subscription
-// begins consuming. Only applies when no existing record exists in
-// event_subscriptions; established subscriptions resume from their stored position.
+// WithStartFrom returns a [cqrs.SubscriberOption] that sets the global event
+// position from which a new subscription begins consuming. It only applies
+// when name has no existing record in event_subscriptions; an already
+// established subscription resumes from its stored position regardless. It
+// panics if applied to a bus other than this package's [EventBus].
 func WithStartFrom(pos int64) cqrs.SubscriberOption {
 	return func(cfg any) {
 		opts, ok := cfg.(*subscriberOptions)
@@ -409,8 +459,10 @@ func WithStartFrom(pos int64) cqrs.SubscriberOption {
 	}
 }
 
-// WithFilterEvents restricts the subscriber to only receive events whose
-// event_type matches one of the provided names.
+// WithFilterEvents returns a [cqrs.SubscriberOption] that restricts the
+// subscriber to events whose event_type matches one of types. Without this
+// option, a subscriber receives every event. It panics if applied to a bus
+// other than this package's [EventBus].
 func WithFilterEvents(types []string) cqrs.SubscriberOption {
 	return func(cfg any) {
 		opts, ok := cfg.(*subscriberOptions)

--- a/eventstore.go
+++ b/eventstore.go
@@ -4,82 +4,54 @@ import (
 	"context"
 )
 
-// EventStore defines the contract for an append-only event store
-// used in event-sourced systems. An EventStore persists events
-// associated with a given aggregate ID in sequential order, allowing
-// for full reconstruction of aggregate state at any point in time.
+// EventStore is an append-only store of [Envelope]s, grouped into per-
+// aggregate streams, that allows an aggregate's state to be reconstructed by
+// replaying its stream.
 //
-// Implementations must guarantee:
-//   - Events for a given aggregate are stored in order.
-//   - Concurrency control based on the aggregate's expected version.
-//   - Iteration order from all Load* methods is deterministic (oldest → newest).
-//
-// The returned iter.Seq values are lazy iterators over the stored events.
-// They should be consumed immediately; no assumptions should be made about
-// reusability or thread-safety after iteration completes.
+// Implementations must store events for a given stream in the order they
+// were saved and yield them in that same order — oldest first — from every
+// Load* method. The [Iterator] values Load* methods return are lazy and
+// should be consumed promptly; implementations make no guarantee about
+// their reusability or thread-safety once iteration ends.
 type EventStore interface {
-	// Save appends all events in the given slice to the event stream for a specific aggregate.
-	//
-	// Parameters:
-	//   - ctx: Request-scoped context for cancellation and tracing.
-	//   - events: A slice of Envelope values to append. Each envelope should have
-	//     the aggregate ID and version set consistently.
-	//   - revision: The expected stream state or concurrency requirement. This can
-	//     be one of:
-	//       - Any: always append, do not check for conflicts.
-	//       - NoStream: stream must not exist; fail if it does.
-	//       - StreamExists: stream must exist; fail if it does not.
-	//
-	// Errors:
-	//   - ErrConcurrency if the originalVersion does not match.
-	//   - Any store-specific persistence error.
+	// Save appends events to the stream identified by their common StreamID,
+	// which must be the same across every element of events. revision states
+	// the caller's expectation of the stream's current state — [Any] to
+	// append unconditionally, [NoStream] to require the stream not already
+	// exist, [StreamExists] to require that it does, or a specific [Revision]
+	// to require an exact version — and Save returns a
+	// [StreamRevisionConflictError] if that expectation does not hold.
 	Save(ctx context.Context, events []Envelope, revision StreamState) (AppendResult, error)
 
-	// LoadStream loads all events for the given aggregate ID from version 0 onward.
-	//
-	// The returned iterator yields events in ascending version order.
-	// Iteration stops if:
-	//   - The iterator function returns false (consumer stops early).
-	//   - The context is canceled.
-	//
-	// Returns:
-	//   - iter.Seq[*Envelope]: Lazy iterator over events.
-	//   - error: Non-nil if the store could not read events.
+	// LoadStream returns an iterator over every event in id's stream, in
+	// ascending version order.
 	LoadStream(ctx context.Context, id string) (*Iterator[*Envelope], error)
 
-	// LoadStreamFrom loads all events for the given aggregate ID starting at the specified version.
-	//
-	// Parameters:
-	//   - ctx: Request-scoped context for cancellation and tracing.
-	//   - id: Aggregate identifier.
-	//   - version: Zero-based version index from which to start iteration.
-	//
-	// Returns:
-	//   - EnvelopeIterator: Lazy iterator over events from
+	// LoadStreamFrom returns an iterator over id's stream starting at
+	// version, in ascending version order. version is typically a
+	// [Revision]; [Any] starts from the beginning of the stream.
 	LoadStreamFrom(ctx context.Context, id string, version StreamState) (*Iterator[*Envelope], error)
 
-	// LoadFromAll loads all events from all aggregates starting at the specified version index.
-	//
-	// The definition of "version" here is store-specific; it may represent:
-	//   - A global monotonically increasing sequence number across all aggregates.
-	//   - A local version within each aggregate (in which case, events are yielded
-	//     from each aggregate starting at that version).
-	//
-	// Events should be yielded in chronological order as stored by the backend.
-	// Consumers should not assume global ordering unless explicitly documented by
-	// the implementation.
+	// LoadFromAll returns an iterator over events across every stream,
+	// starting at version. Whether version and the iteration order it
+	// produces are globally consistent, or only consistent within each
+	// stream, is implementation-specific; consult the implementation before
+	// relying on cross-stream ordering.
 	LoadFromAll(ctx context.Context, version StreamState) (*Iterator[*Envelope], error)
+
 	// Close releases any resources held by the EventStore, such as network
-	// connections or file handles. After Close is called, the EventStore should
-	// not be used.
-	//
-	// Implementations should make Close idempotent.
+	// connections or file handles. Implementations should make Close
+	// idempotent. The EventStore must not be used after Close is called.
 	Close() error
 }
 
-// AppendResult describes the outcome of an append operation.
+// AppendResult describes the outcome of an [EventStore.Save] call.
 type AppendResult struct {
-	Successful          bool
-	StreamID            string
+	// Successful reports whether the events were persisted.
+	Successful bool
+	// StreamID is the stream the events were saved to.
+	StreamID string
+	// NextExpectedVersion is the version the stream's next [Revision] should
+	// use.
 	NextExpectedVersion uint64
 }

--- a/eventstore/file/filestorage.go
+++ b/eventstore/file/filestorage.go
@@ -18,6 +18,11 @@ import (
 
 var _ cqrs.EventStore = (*FilesStore)(nil)
 
+// FilesStore is a file-backed [cqrs.EventStore] intended for tests and local
+// development. Each stream's events are stored as one JSON file per event
+// under a directory named after the stream ID, and a symlink to every event
+// is also kept under an "all" directory to support [FilesStore.LoadFromAll].
+// It is safe for concurrent use.
 type FilesStore struct {
 	baseDir   string
 	mu        sync.Mutex
@@ -25,6 +30,8 @@ type FilesStore struct {
 	globalSeq uint64
 }
 
+// NewFileStore creates a [FilesStore] rooted at dir, creating dir and its
+// "all" subdirectory if they do not already exist.
 func NewFileStore(dir string) (*FilesStore, error) {
 	if err := os.MkdirAll(filepath.Join(dir, "all"), 0o755); err != nil {
 		return nil, err
@@ -39,6 +46,24 @@ func (f *FilesStore) streamDir(id string) string {
 	return filepath.Join(f.baseDir, id)
 }
 
+// Save appends events to the stream they share, enforcing the concurrency
+// check described by revision: [cqrs.Any] skips it, [cqrs.NoStream] requires
+// the stream not to exist yet, [cqrs.StreamExists] requires that it already
+// does, and a [cqrs.Revision] requires the stream's current length to match
+// exactly, returning a [cqrs.StreamRevisionConflictError] on mismatch. All
+// events must have the same StreamID, or Save returns a non-nil error
+// without appending anything. On success it returns a [cqrs.AppendResult]
+// whose NextExpectedVersion is the stream's new length.
+//
+// TODO: each event is written to a file named after its own Version field
+// (e.g. "0000000002-Foo.json"), but Save never assigns that field itself —
+// unlike the postgres and kurrentdb implementations of this interface, which
+// compute the position server-side. If the caller does not set Version to a
+// value that is unique and sequential within the stream (for example, if it
+// is left at its zero value across a multi-event batch), later events
+// silently overwrite earlier ones on disk and Save still reports success
+// with no error (confirmed: saving 3 events with Version left unset leaves
+// only 1 file, and LoadStream then returns only that 1 event).
 func (f *FilesStore) Save(ctx context.Context, events []cqrs.Envelope, revision cqrs.StreamState) (cqrs.AppendResult, error) {
 	if len(events) == 0 {
 		return cqrs.AppendResult{Successful: true}, nil
@@ -151,18 +176,38 @@ func (f *FilesStore) Save(ctx context.Context, events []cqrs.Envelope, revision 
 
 }
 
+// LoadStream returns a lazy iterator over all events in the stream
+// identified by id, in the order they were appended. It returns a non-nil
+// error if the stream does not exist.
 func (f *FilesStore) LoadStream(ctx context.Context, id string) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	return f.loadFromDir(f.streamDir(id), cqrs.StreamExists{})
 }
 
+// LoadStreamFrom returns a lazy iterator over the events in the stream
+// identified by id, starting at the position identified by version. A
+// [cqrs.Revision] starts at that index; [cqrs.NoStream] requires the stream
+// not to exist and returns a non-nil error if it does; [cqrs.StreamExists]
+// requires that it does exist and returns a non-nil error if it does not;
+// any other [cqrs.StreamState], including [cqrs.Any], reads from the
+// beginning of the stream. It also returns a non-nil error if the requested
+// revision is beyond the stream's current length.
 func (f *FilesStore) LoadStreamFrom(ctx context.Context, id string, version cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	return f.loadFromDir(f.streamDir(id), version)
 }
 
+// LoadFromAll returns a lazy iterator over every event saved across all
+// streams, ordered by the [cqrs.Envelope] GlobalVersion assigned when each
+// event was appended. version is interpreted the same way as in
+// [FilesStore.LoadStreamFrom], but against the global sequence rather than a
+// single stream.
 func (f *FilesStore) LoadFromAll(ctx context.Context, version cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	return f.loadFromDir(filepath.Join(f.baseDir, "all"), version)
 }
 
+// loadFromDir is the shared implementation behind LoadStream, LoadStreamFrom,
+// and LoadFromAll: it lists dir, applies the precondition or starting offset
+// described by from, and returns a lazy iterator over the decoded events in
+// filename order.
 func (f *FilesStore) loadFromDir(dir string, from cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	files, err := os.ReadDir(dir)
 	if err != nil {
@@ -256,15 +301,27 @@ func (f *FilesStore) loadFromDir(dir string, from cqrs.StreamState) (*cqrs.Itera
 	return cqrs.NewIteratorFunc(nextFunc), nil
 }
 
+// Events returns a channel that receives every [cqrs.Envelope] as it is
+// saved. It is not part of the [cqrs.EventStore] interface; it exists so
+// tests and local tooling can observe writes as they happen. The channel has
+// a fixed buffer of 100 and sends are non-blocking, so a slow consumer
+// misses events rather than blocking Save. The channel is closed by Close.
 func (f *FilesStore) Events() <-chan *cqrs.Envelope {
 	return f.bus
 }
 
+// Close closes the channel returned by Events. After Close, the FilesStore
+// must not be used again.
+//
+// TODO: this is not idempotent, contrary to the cqrs.EventStore contract,
+// which asks implementations to make Close safe to call more than once — a
+// second call panics with "close of closed channel".
 func (f *FilesStore) Close() error {
 	close(f.bus)
 	return nil
 }
 
+// storedEvent is the on-disk JSON representation of a saved [cqrs.Envelope].
 type storedEvent struct {
 	EventID       uuid.UUID       `json:"event_id"`
 	StreamID      string          `json:"stream_id"`

--- a/eventstore/kurrentdb/eventstore.go
+++ b/eventstore/kurrentdb/eventstore.go
@@ -15,17 +15,38 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// eventstore is a KurrentDB-backed [cqrs.EventStore], delegating stream
+// storage, ordering, and revision checks to the KurrentDB server itself.
 type eventstore struct {
 	client *kurrentdb.Client
 }
 
-// NewEventStore creates a KurrentDB-backed eventstore
+// NewEventStore returns a KurrentDB-backed [cqrs.EventStore] that uses db for
+// all operations.
 func NewEventStore(db *kurrentdb.Client) cqrs.EventStore {
 	return &eventstore{
 		client: db,
 	}
 }
 
+// Save appends events to the stream they share, translating revision into
+// the equivalent KurrentDB stream-state expectation: [cqrs.Any] skips the
+// check, [cqrs.NoStream] requires the stream not to exist yet,
+// [cqrs.StreamExists] requires that it already does, and a [cqrs.Revision]
+// requires the stream's current revision to match exactly. All events must
+// have the same StreamID, or Save returns a non-nil error without contacting
+// the server. The append is retried with backoff on transient gRPC errors
+// (such as those from an in-progress leader election), for up to 30 seconds
+// or 10 attempts. On success it returns a [cqrs.AppendResult] whose
+// NextExpectedVersion is the stream's new revision as reported by KurrentDB.
+//
+// TODO: on a revision conflict, the returned cqrs.StreamRevisionConflictError
+// only has its Stream field set — ExpectedRevision and ActualRevision are
+// left as their zero value (a nil cqrs.StreamState). Calling Error() on that
+// value panics with a nil pointer dereference (confirmed), because
+// StreamRevisionConflictError.Error calls ToRawInt64() on both fields. Any
+// caller that logs or formats this error today will crash instead of seeing
+// a conflict message.
 func (e eventstore) Save(ctx context.Context, events []cqrs.Envelope, revision cqrs.StreamState) (cqrs.AppendResult, error) {
 	if len(events) == 0 {
 		return cqrs.AppendResult{Successful: true, NextExpectedVersion: 0}, nil
@@ -121,7 +142,11 @@ func (e eventstore) Save(ctx context.Context, events []cqrs.Envelope, revision c
 	if err != nil {
 		var conflictErr *kurrentdb.StreamRevisionConflictError
 		if errors.As(err, &conflictErr) {
-			//TODO extract the actual revisions..
+			// TODO: extract the actual revisions from conflictErr (the
+			// commented-out fields below). As written, ExpectedRevision and
+			// ActualRevision are left nil, and StreamRevisionConflictError.Error
+			// panics when called on a nil cqrs.StreamState. See the Save doc
+			// comment above.
 			return cqrs.AppendResult{
 					Successful: false,
 					StreamID:   streamID,
@@ -147,6 +172,16 @@ func (e eventstore) Save(ctx context.Context, events []cqrs.Envelope, revision c
 
 }
 
+// LoadStream returns a lazy iterator over all events in the stream
+// identified by id, in the order they were appended.
+//
+// TODO: any error opening the read (including a genuine connectivity
+// failure) is currently reported as cqrs.ErrStreamNotFound, and any error
+// received while iterating — including a mid-stream connection drop, not
+// just a clean end of stream — is reported to the iterator as io.EOF, i.e.
+// as if the read had completed successfully. A caller has no way to
+// distinguish "the stream does not exist" or "the read failed partway
+// through" from a normal, complete read.
 func (e eventstore) LoadStream(ctx context.Context, id string) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	streamer, err := e.client.ReadStream(ctx, id, kurrentdb.ReadStreamOptions{
 		Direction:      kurrentdb.Forwards,
@@ -174,7 +209,11 @@ func (e eventstore) LoadStream(ctx context.Context, id string) (*cqrs.Iterator[*
 
 		kEvent, err := streamer.Recv()
 		if err != nil {
-			// Stream finished normally
+			// TODO: this treats every error from Recv (including a real
+			// connection failure, confirmed possible per ReadStream.Recv in
+			// the kurrentdb client) as a normal end of stream, so genuine
+			// failures are silently reported as success. See the doc comment
+			// above.
 			return nil, io.EOF
 		}
 
@@ -210,6 +249,19 @@ func (e eventstore) LoadStream(ctx context.Context, id string) (*cqrs.Iterator[*
 	return iter, nil
 }
 
+// LoadStreamFrom returns a lazy iterator over the events in the stream
+// identified by id, starting at the position identified by version. Only a
+// positive [cqrs.Revision] changes the starting point; version.ToRawInt64()
+// <= 0 — which includes [cqrs.NoStream], [cqrs.StreamExists], [cqrs.Any],
+// and a zero [cqrs.Revision] — all read from the beginning of the stream.
+// Unlike the memory, file, and postgres implementations of this interface,
+// cqrs.NoStream and cqrs.StreamExists are not enforced as existence
+// preconditions here.
+//
+// TODO: as with LoadStream, every error from Recv while iterating —
+// including a real connection failure — is reported to the iterator as
+// io.EOF, i.e. a normal end of stream, so a caller cannot tell a genuine
+// failure apart from a complete read.
 func (e eventstore) LoadStreamFrom(ctx context.Context, id string, version cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	var from kurrentdb.StreamPosition
 	if version.ToRawInt64() > 0 {
@@ -243,7 +295,8 @@ func (e eventstore) LoadStreamFrom(ctx context.Context, id string, version cqrs.
 
 		kEvent, err := streamer.Recv()
 		if err != nil {
-			// Stream finished normally
+			// TODO: see the LoadStreamFrom doc comment above — this masks
+			// real Recv errors as a normal end of stream.
 			return nil, io.EOF
 		}
 
@@ -279,6 +332,13 @@ func (e eventstore) LoadStreamFrom(ctx context.Context, id string, version cqrs.
 	return iter, nil
 }
 
+// LoadFromAll returns a lazy iterator over every event across all streams,
+// in the global order KurrentDB stored them.
+//
+// TODO: version is accepted but never used — every call reads from the very
+// beginning of the $all stream regardless of the position passed in, so
+// there is currently no way to resume a previous LoadFromAll from where it
+// left off (already flagged in the code below).
 func (e eventstore) LoadFromAll(ctx context.Context, version cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	//TODO fix `from`
 
@@ -301,7 +361,8 @@ func (e eventstore) LoadFromAll(ctx context.Context, version cqrs.StreamState) (
 
 		kEvent, err := streamer.Recv()
 		if err != nil {
-			// Stream finished normally
+			// Propagate as-is: io.EOF signals a normal end of stream, any
+			// other error is a genuine failure.
 			return nil, err
 		}
 
@@ -337,11 +398,13 @@ func (e eventstore) LoadFromAll(ctx context.Context, version cqrs.StreamState) (
 	return iter, nil
 }
 
+// Close closes the underlying KurrentDB client connection.
 func (e eventstore) Close() error {
 	return e.client.Close()
 }
 
-// isRetryableError determines if an error should trigger a retry
+// isRetryableError reports whether err is a transient gRPC error worth
+// retrying (as opposed to a permanent failure such as an invalid argument).
 func isRetryableError(err error) bool {
 	s, ok := status.FromError(err)
 	if !ok {

--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -13,6 +13,10 @@ import (
 
 var _ eventsourcing.EventStore = (*MemoryStore)(nil)
 
+// MemoryStore is an in-memory [eventsourcing.EventStore] intended for tests
+// and local development. It keeps every stream and the global event log in a
+// single process's memory, so its contents do not survive a restart and it
+// cannot be shared across processes. It is safe for concurrent use.
 type MemoryStore struct {
 	tracer trace.Tracer
 	mu     sync.RWMutex
@@ -21,6 +25,12 @@ type MemoryStore struct {
 	events map[string][]*eventsourcing.Envelope
 }
 
+// LoadFromAll returns a lazy iterator over every event ever saved, across all
+// streams, in the order they were appended, starting at the position
+// identified by version. version is expected to be an
+// [eventsourcing.Revision] (or [eventsourcing.NoStream], which behaves like
+// revision 0); it returns a non-nil error if that position is beyond the
+// number of events currently stored.
 func (m *MemoryStore) LoadFromAll(ctx context.Context, version eventsourcing.StreamState) (*eventsourcing.Iterator[*eventsourcing.Envelope], error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -33,6 +43,14 @@ func (m *MemoryStore) LoadFromAll(ctx context.Context, version eventsourcing.Str
 		)
 	}
 
+	// TODO: unlike LoadStreamFrom, this does not type-switch on version, so
+	// eventsourcing.Any.ToRawInt64() (-1) and eventsourcing.StreamExists.ToRawInt64()
+	// (-2) are cast directly to uint64 below, producing a huge offset that
+	// indexes allEvents out of range and panics instead of returning an
+	// error (confirmed: LoadFromAll(ctx, eventsourcing.Any{}) panics with
+	// "index out of range" on the first Next() call, even against an empty
+	// store). Only eventsourcing.Revision and eventsourcing.NoStream (0)
+	// currently work correctly.
 	var offset = uint64(version.ToRawInt64())
 
 	iter := eventsourcing.NewIteratorFunc(func(ctx context.Context) (*eventsourcing.Envelope, error) {
@@ -50,6 +68,18 @@ func (m *MemoryStore) LoadFromAll(ctx context.Context, version eventsourcing.Str
 	return iter, nil
 }
 
+// Save appends events to the stream they share, atomically and under the
+// store's lock: either all of them are appended or, on a validation or
+// concurrency failure, none are. All events must have the same StreamID, or
+// Save returns a non-nil error without appending anything.
+//
+// revision controls the concurrency check: [eventsourcing.Any] skips it,
+// [eventsourcing.NoStream] requires the stream not to exist yet,
+// [eventsourcing.StreamExists] requires that it already does, and an
+// [eventsourcing.Revision] requires the stream's current length to match
+// exactly, returning a [eventsourcing.StreamRevisionConflictError] on
+// mismatch. On success it returns an [eventsourcing.AppendResult] whose
+// NextExpectedVersion is the stream's new length.
 func (m *MemoryStore) Save(ctx context.Context, events []eventsourcing.Envelope, revision eventsourcing.StreamState) (eventsourcing.AppendResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -122,10 +152,22 @@ func (m *MemoryStore) Save(ctx context.Context, events []eventsourcing.Envelope,
 	}, nil
 }
 
+// LoadStream returns a lazy iterator over all events in the stream
+// identified by id, in the order they were appended. It returns a non-nil
+// error if the stream does not exist.
 func (m *MemoryStore) LoadStream(ctx context.Context, id string) (*eventsourcing.Iterator[*eventsourcing.Envelope], error) {
 	return m.LoadStreamFrom(ctx, id, eventsourcing.StreamExists{})
 }
 
+// LoadStreamFrom returns a lazy iterator over the events in the stream
+// identified by id, starting at the position identified by version. An
+// [eventsourcing.Revision] starts at that index; [eventsourcing.NoStream]
+// requires the stream not to exist and returns a non-nil error if it does;
+// [eventsourcing.StreamExists] requires that it does exist and returns a
+// non-nil error if it does not; any other [eventsourcing.StreamState],
+// including [eventsourcing.Any], reads from the beginning of the stream. It
+// also returns a non-nil error if the requested revision is beyond the
+// stream's current length.
 func (m *MemoryStore) LoadStreamFrom(ctx context.Context, id string, version eventsourcing.StreamState) (*eventsourcing.Iterator[*eventsourcing.Envelope], error) {
 
 	m.mu.RLock()
@@ -175,10 +217,22 @@ func (m *MemoryStore) LoadStreamFrom(ctx context.Context, id string, version eve
 	return iter, nil
 }
 
+// Events returns a channel that receives every [eventsourcing.Envelope] as it
+// is saved. It is not part of the [eventsourcing.EventStore] interface; it
+// exists so tests and local tooling can observe writes as they happen. The
+// channel has the buffer size passed to [NewMemoryStore] and sends are
+// non-blocking, so a slow consumer misses events rather than blocking Save.
+// The channel is closed by Close.
 func (m *MemoryStore) Events() <-chan *eventsourcing.Envelope {
 	return m.bus
 }
 
+// Close discards all stored events and closes the channel returned by
+// Events. After Close, the MemoryStore must not be used again.
+//
+// TODO: this is not idempotent, contrary to the eventsourcing.EventStore
+// contract, which asks implementations to make Close safe to call more than
+// once — a second call panics with "close of closed channel" (confirmed).
 func (m *MemoryStore) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -187,6 +241,8 @@ func (m *MemoryStore) Close() error {
 	return nil
 }
 
+// NewMemoryStore constructs an empty [MemoryStore]. buffer sets the capacity
+// of the channel returned by [MemoryStore.Events].
 func NewMemoryStore(buffer int64) *MemoryStore {
 	return &MemoryStore{
 		events: make(map[string][]*eventsourcing.Envelope),

--- a/eventstore/postgres/eventstore.go
+++ b/eventstore/postgres/eventstore.go
@@ -20,16 +20,33 @@ const pgUniqueViolation = "23505"
 
 var _ cqrs.EventStore = (*eventstore)(nil)
 
+// eventstore is a PostgreSQL-backed [cqrs.EventStore]. Stream membership and
+// per-stream ordering are recorded in the events table's stream_id and
+// stream_position columns; the table's own auto-incrementing id column
+// provides the global order consumed by LoadFromAll.
 type eventstore struct {
 	pool *pgxpool.Pool
 }
 
-// NewEventStore returns a PostgreSQL-backed EventStore.
-// The pool must be configured to connect to a database containing the events table.
+// NewEventStore returns a PostgreSQL-backed [cqrs.EventStore]. The pool must
+// already be configured to connect to a database containing the events
+// table; NewEventStore does not create or migrate the schema.
 func NewEventStore(pool *pgxpool.Pool) cqrs.EventStore {
 	return &eventstore{pool: pool}
 }
 
+// Save appends events to the stream they share, enforcing the concurrency
+// check described by revision: [cqrs.Any] skips it, [cqrs.NoStream] requires
+// the stream not to exist yet, [cqrs.StreamExists] requires that it already
+// does, and a [cqrs.Revision] requires the stream's current length to match
+// exactly. All events must have the same StreamID, or Save returns a
+// non-nil error without appending anything. The whole append happens inside
+// a transaction serialized against other writers to the same stream by a
+// Postgres advisory lock, so on a revision mismatch — whether caught by the
+// check above or by a unique-constraint violation from a concurrent writer —
+// it returns a [cqrs.StreamRevisionConflictError] and nothing is persisted.
+// On success it returns a [cqrs.AppendResult] whose NextExpectedVersion is
+// the stream's new length.
 func (s *eventstore) Save(ctx context.Context, events []cqrs.Envelope, revision cqrs.StreamState) (cqrs.AppendResult, error) {
 	if len(events) == 0 {
 		return cqrs.AppendResult{Successful: true}, nil
@@ -156,6 +173,9 @@ func (s *eventstore) Save(ctx context.Context, events []cqrs.Envelope, revision 
 	}, nil
 }
 
+// LoadStream returns a lazy iterator over all events in the stream
+// identified by id, in the order they were appended. It returns a non-nil
+// error if the stream does not exist.
 func (s *eventstore) LoadStream(ctx context.Context, id string) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	var exists bool
 	if err := s.pool.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM events WHERE stream_id = $1)", id).Scan(&exists); err != nil {
@@ -170,6 +190,16 @@ func (s *eventstore) LoadStream(ctx context.Context, id string) (*cqrs.Iterator[
 		FROM events WHERE stream_id = $1 ORDER BY stream_position ASC`, id)
 }
 
+// LoadStreamFrom returns a lazy iterator over the events in the stream
+// identified by id, starting after the position identified by version.
+// [cqrs.NoStream] requires the stream not to exist and returns a non-nil
+// error if it does; [cqrs.StreamExists] requires that it does exist and
+// returns a non-nil error if it does not; [cqrs.Any] reads from the
+// beginning of the stream. Any other [cqrs.StreamState] — in practice a
+// [cqrs.Revision] of n — is treated as a position, and events after it are
+// returned, so a caller that has already processed n events resumes exactly
+// where it left off; a zero revision behaves like reading from the
+// beginning.
 func (s *eventstore) LoadStreamFrom(ctx context.Context, id string, version cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	switch version.(type) {
 	case cqrs.NoStream:
@@ -209,6 +239,15 @@ func (s *eventstore) LoadStreamFrom(ctx context.Context, id string, version cqrs
 	}
 }
 
+// LoadFromAll returns a lazy iterator over every event saved across all
+// streams, in the global order they were committed, starting after the
+// position identified by version (per its ToRawInt64, so [cqrs.Any],
+// [cqrs.NoStream], and [cqrs.StreamExists] all behave like reading from the
+// very beginning). It only returns events from transactions that had
+// already committed when the read began, so a transaction that is still
+// in-flight — even if it inserted a row with a lower id than one already
+// visible — cannot be skipped over and later missed by a subsequent call
+// with a higher version.
 func (s *eventstore) LoadFromAll(ctx context.Context, version cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	fromID := version.ToRawInt64()
 	return s.queryRows(ctx, `
@@ -219,13 +258,16 @@ func (s *eventstore) LoadFromAll(ctx context.Context, version cqrs.StreamState) 
 		ORDER BY id ASC`, fromID)
 }
 
+// Close closes the underlying connection pool. It is safe to call more than
+// once.
 func (s *eventstore) Close() error {
 	s.pool.Close()
 	return nil
 }
 
-// queryRows executes a SELECT and returns a lazy Iterator over the resulting Envelopes.
-// The database connection is held open until the iterator is exhausted or an error occurs.
+// queryRows executes a SELECT and returns a lazy [cqrs.Iterator] over the
+// resulting [cqrs.Envelope] values. The underlying rows are held open until
+// the iterator is exhausted or an error occurs.
 func (s *eventstore) queryRows(ctx context.Context, sql string, args ...any) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	rows, err := s.pool.Query(ctx, sql, args...)
 	if err != nil {
@@ -249,6 +291,8 @@ func (s *eventstore) queryRows(ctx context.Context, sql string, args ...any) (*c
 	}), nil
 }
 
+// scanEnvelope decodes a single events row into a [cqrs.Envelope],
+// reconstructing the concrete [cqrs.Event] via [cqrs.NewEventByName].
 func scanEnvelope(rows pgx.Rows) (*cqrs.Envelope, error) {
 	var (
 		globalID       int64

--- a/iter.go
+++ b/iter.go
@@ -5,41 +5,20 @@ import (
 	"io"
 )
 
+// IterFunc produces the next item of type T, returning [io.EOF] once
+// iteration is complete.
 type IterFunc[T any] func(ctx context.Context) (T, error)
 
-// Iterator is a generic, type-safe iterator over items of type T.
+// Iterator is a pull-based iterator over items of type T, driven by an
+// [IterFunc] supplied through [NewIteratorFunc] or [NewSliceIterator]. It
+// underlies the event streams returned by an [EventStore]'s Load* methods,
+// but its next-function can equally paginate, stream, or buffer
+// asynchronously — whatever the source needs.
 //
-// It abstracts the iteration logic, allowing for multiple iteration strategies
-// such as paginated fetching, streaming, or pre-filling a buffer asynchronously.
-//
-// The iterator provides the following API:
-//   - Next(ctx): advances the iterator and reports whether a next value exists.
-//   - Value(): retrieves the current value after Next() returns true.
-//   - Err(): retrieves any error encountered during iteration.
-//   - All(ctx): consumes the iterator fully and returns all items as a slice.
-//
-// Type Parameters:
-//   - T: The item type returned by the iterator. Can be a pointer, struct, or primitive.
-//
-// Example Usage:
-//
-//	items := []int{1, 2, 3, 4, 5}
-//	i := 0
-//	iter := NewIteratorFunc(func(ctx context.Context) (int, error) {
-//	    if i >= len(items) {
-//	        return 0, io.EOF
-//	    }
-//	    val := items[i]
-//	    i++
-//	    return val, nil
-//	})
-//
-//	for iter.Next(context.Background()) {
-//	    fmt.Println(iter.Value())
-//	}
-//	if err := iter.Err(); err != nil {
-//	    panic(err)
-//	}
+// Call Next repeatedly to advance the iterator, reading the current item
+// with Value after each call that returns true; when Next returns false,
+// call Err to distinguish a clean end of iteration (nil) from a failure. See
+// [ExampleNewIteratorFunc].
 type Iterator[T any] struct {
 	// nextFunc is the function that produces the next value in the iteration.
 	// It must return:
@@ -58,23 +37,9 @@ type Iterator[T any] struct {
 	done bool
 }
 
-// Next advances the iterator to the next value.
-//
-// Returns:
-//   - bool: true if a new value is available; false if iteration is complete
-//     or an error occurred.
-//
-// Behavior:
-//   - Calls nextFunc to retrieve the next item.
-//   - If nextFunc returns io.EOF, marks iteration as done and returns false.
-//   - If nextFunc returns a non-nil error, stores it and returns false.
-//   - Otherwise, stores the item in current and returns true.
-//
-// Example:
-//
-//	if iter.Next(ctx) {
-//	    item := iter.Value()
-//	}
+// Next advances the iterator and reports whether a new value is available.
+// It returns false once the underlying [IterFunc] reports [io.EOF] or
+// returns any other error; call Err afterward to tell the two apart.
 func (it *Iterator[T]) Next(ctx context.Context) bool {
 	if it.done || it.err != nil {
 		return false
@@ -96,38 +61,21 @@ func (it *Iterator[T]) Next(ctx context.Context) bool {
 	return true
 }
 
-// Value returns the current item in the iteration.
-//
-// Returns:
-//   - T: the current item, or the zero value if Next() has not been called
-//     or iteration has completed.
-//
-// Usage:
-//
-//	item := iter.Value()
+// Value returns the item read by the most recent call to Next, or the zero
+// value of T if Next has not been called or has returned false.
 func (it *Iterator[T]) Value() T {
 	return it.current
 }
 
-// Err returns the last error encountered during iteration.
-//
-// Returns:
-//   - error: the error returned by nextFunc, if any. Returns nil if iteration
-//     completed normally.
+// Err returns the error that ended iteration, or nil if Next has not yet
+// returned false or iteration completed because the source was exhausted.
 func (it *Iterator[T]) Err() error {
 	return it.err
 }
 
-// All consumes the iterator and returns all remaining items in a slice.
-//
-// Returns:
-//   - []T: all items produced by the iterator
-//   - error: the first non-EOF error encountered, or nil if iteration completed normally.
-//
-// Behavior:
-//   - Repeatedly calls Next() until it returns false.
-//   - Collects all items via Value().
-//   - Returns any error encountered via Err().
+// All consumes the iterator by calling Next until it returns false,
+// collecting each Value along the way, and returns the collected items
+// along with the result of Err.
 func (it *Iterator[T]) All(ctx context.Context) ([]T, error) {
 	var results []T
 	for it.Next(ctx) {
@@ -136,42 +84,15 @@ func (it *Iterator[T]) All(ctx context.Context) ([]T, error) {
 	return results, it.Err()
 }
 
-// NewIteratorFunc constructs a new Iterator[T] using the provided nextFunc.
-//
-// Parameters:
-//   - nextFunc: function that produces the next item. Must return:
-//     (T, nil) for valid items
-//     (any, io.EOF) to signal end of iteration
-//     (any, error) to signal a failure
-//
-// Returns:
-//   - *Iterator[T]: a new iterator ready for consumption via Next()/All()
-//
-// Example:
-//
-//	iter := NewIteratorFunc(func(ctx context.Context) (int, error) {
-//	    if i >= len(items) {
-//	        return 0, io.EOF
-//	    }
-//	    val := items[i]
-//	    i++
-//	    return val, nil
-//	})
+// NewIteratorFunc returns an [Iterator] driven by nextFunc, which must
+// return [io.EOF] to signal the end of iteration and any other error to
+// signal a failure.
 func NewIteratorFunc[T any](nextFunc func(ctx context.Context) (T, error)) *Iterator[T] {
 	return &Iterator[T]{nextFunc: nextFunc}
 }
 
-// NewSliceIterator constructs a new Iterator[T] using the provided slice T.
-//
-// Parameters:
-//   - slice: []T
-//
-// Returns:
-//   - *Iterator[T]: a new iterator ready for consumption via Next()/All()
-//
-// Example:
-//
-//	iter := NewSliceIterator([]int{1,2,3,4,5})
+// NewSliceIterator returns an [Iterator] that yields the elements of slice
+// in order.
 func NewSliceIterator[T any](slice []T) *Iterator[T] {
 	index := 0
 

--- a/iter_test.go
+++ b/iter_test.go
@@ -3,11 +3,39 @@ package eventsourcing_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"testing"
 
 	cqrs "github.com/terraskye/eventsourcing"
 )
+
+func ExampleNewIteratorFunc() {
+	items := []int{1, 2, 3, 4, 5}
+	i := 0
+
+	iter := cqrs.NewIteratorFunc(func(ctx context.Context) (int, error) {
+		if i >= len(items) {
+			return 0, io.EOF
+		}
+		val := items[i]
+		i++
+		return val, nil
+	})
+
+	for iter.Next(context.Background()) {
+		fmt.Println(iter.Value())
+	}
+	if err := iter.Err(); err != nil {
+		panic(err)
+	}
+	// Output:
+	// 1
+	// 2
+	// 3
+	// 4
+	// 5
+}
 
 func TestIteratorBasic(t *testing.T) {
 	items := []int{1, 2, 3}

--- a/logging/command_handler.go
+++ b/logging/command_handler.go
@@ -8,9 +8,10 @@ import (
 	"github.com/terraskye/eventsourcing"
 )
 
-// WithCommandLogging wraps a CommandHandler with logging functionality.
-// It logs the command type and aggregate ID before execution, and logs
-// errors if the command fails.
+// WithCommandLogging wraps next so that every invocation is logged. Before
+// calling next it logs the command's concrete type and
+// [eventsourcing.Command.AggregateID]; if next returns an error, that error is
+// logged as well.
 func WithCommandLogging[C eventsourcing.Command](logger *slog.Logger, next eventsourcing.CommandHandler[C]) eventsourcing.CommandHandler[C] {
 
 	return func(ctx context.Context, command C) (eventsourcing.AppendResult, error) {
@@ -26,8 +27,10 @@ func WithCommandLogging[C eventsourcing.Command](logger *slog.Logger, next event
 	}
 }
 
-// CommandLogging returns a CommandHandlerMiddleware that logs every command dispatched
-// through the bus. Use with bus.Use() to apply logging to all registered handlers.
+// CommandLogging returns an [eventsourcing.CommandHandlerMiddleware] that logs
+// every command dispatched through a [eventsourcing.CommandBus]: its type and
+// aggregate ID before it runs, and any error it returns. Register it with
+// [eventsourcing.CommandBus.Use] to apply logging to all handlers on the bus.
 func CommandLogging(logger *slog.Logger) eventsourcing.CommandHandlerMiddleware {
 	return func(next eventsourcing.CommandHandler[eventsourcing.Command]) eventsourcing.CommandHandler[eventsourcing.Command] {
 		return func(ctx context.Context, cmd eventsourcing.Command) (eventsourcing.AppendResult, error) {

--- a/logging/event_handler.go
+++ b/logging/event_handler.go
@@ -7,14 +7,21 @@ import (
 	cqrs "github.com/terraskye/eventsourcing"
 )
 
-// EventLogging returns an EventHandlerMiddleware that logs event processing.
-// Use with NewMiddlewareEventBus().Use() to apply logging to all subscribers.
+// EventLogging returns an [cqrs.EventHandlerMiddleware] that logs event
+// processing. Register it with [cqrs.EventBus.Use] — for example on the bus
+// returned by memory.NewEventBus or postgres.NewEventBus — to apply logging to
+// every subscriber on that bus.
 func EventLogging(logger *slog.Logger) cqrs.EventHandlerMiddleware {
 	return func(next cqrs.EventHandler) cqrs.EventHandler {
 		return WithLoggingMiddleware(logger, next)
 	}
 }
 
+// WithLoggingMiddleware wraps next so that every event it handles is logged.
+// It logs a debug message before and after the call, both carrying the stream
+// ID, causation, version, global version, and aggregate ID found on ctx, plus
+// the event's [cqrs.Event.EventType]. If next returns an error, that error is
+// logged instead of the "processed successfully" message.
 func WithLoggingMiddleware(logger *slog.Logger, next cqrs.EventHandler) cqrs.EventHandler {
 	return cqrs.NewEventHandlerFunc(func(ctx context.Context, event cqrs.Event) error {
 		l := logger.With(

--- a/logging/query_handler.go
+++ b/logging/query_handler.go
@@ -8,11 +8,15 @@ import (
 	"github.com/terraskye/eventsourcing"
 )
 
+// queryHandlerLogger wraps an [eventsourcing.QueryHandler] with logging.
 type queryHandlerLogger[T eventsourcing.Query, R any] struct {
 	logger *slog.Logger
 	next   eventsourcing.QueryHandler[T, R]
 }
 
+// HandleQuery implements [eventsourcing.QueryHandler] by logging the query's
+// concrete type before delegating to the wrapped handler, and logging the
+// error if that call fails.
 func (q *queryHandlerLogger[T, R]) HandleQuery(ctx context.Context, qry T) (R, error) {
 	qryType := fmt.Sprintf("%T", qry)
 	q.logger.InfoContext(ctx, "Query", "query", qryType)
@@ -25,8 +29,8 @@ func (q *queryHandlerLogger[T, R]) HandleQuery(ctx context.Context, qry T) (R, e
 	return result, err
 }
 
-// WithQueryLogging wraps a QueryHandler with logging functionality.
-// It logs the query type before execution, and logs errors if the query fails.
+// WithQueryLogging wraps next so that every query it handles is logged: its
+// concrete type before the call, and the error if the call fails.
 func WithQueryLogging[T eventsourcing.Query, R any](logger *slog.Logger, next eventsourcing.QueryHandler[T, R]) eventsourcing.QueryHandler[T, R] {
 	return &queryHandlerLogger[T, R]{
 		logger: logger,
@@ -34,8 +38,10 @@ func WithQueryLogging[T eventsourcing.Query, R any](logger *slog.Logger, next ev
 	}
 }
 
-// QueryLogging returns a QueryHandlerMiddleware that logs every query dispatched
-// through the bus. Use with bus.Use() to apply logging to all registered handlers.
+// QueryLogging returns an [eventsourcing.QueryHandlerMiddleware] that logs
+// every query dispatched through a [eventsourcing.QueryBus]: its type before
+// it runs, and any error it returns. Register it with
+// [eventsourcing.QueryBus.Use] to apply logging to all handlers on the bus.
 func QueryLogging(logger *slog.Logger) eventsourcing.QueryHandlerMiddleware {
 	return func(next eventsourcing.QueryGateway[eventsourcing.Query, any]) eventsourcing.QueryGateway[eventsourcing.Query, any] {
 		return func(ctx context.Context, qry eventsourcing.Query) (any, error) {

--- a/middleware.go
+++ b/middleware.go
@@ -77,8 +77,14 @@ func (b *CommandBus) Use(middlewares ...CommandHandlerMiddleware) {
 //	bus.Use(myMiddleware)
 type QueryHandlerMiddleware func(next QueryGateway[Query, any]) QueryGateway[Query, any]
 
-// Use adds one or more middlewares to the QueryBus.
-// Must be called before RegisterQueryHandler; middleware is baked in at registration time.
+// Use appends middlewares to the chain applied to query handlers. The first
+// one appended is the outermost wrapper and runs first on each query.
+//
+// Use must be called before [RegisterQueryHandler] or
+// [RegisterQueryHandlerFunc]: the chain is baked into each handler at
+// registration time, so handlers already registered are not re-wrapped and a
+// later Use call has no effect on them. Configure the full chain during
+// startup wiring.
 //
 // Example Usage:
 //
@@ -121,19 +127,13 @@ func wrapQueryHandler[T Query, R any](h QueryHandler[T, R], middlewares []QueryH
 	})
 }
 
-// EventHandlerMiddleware defines a function type for decorating event handlers on an EventBus.
-// Middlewares are applied when a handler is passed to Subscribe, wrapping it with
-// cross-cutting concerns such as logging, telemetry, or error handling.
-//
-// Parameters:
-//   - next: The next EventHandler in the chain. Call it to pass the event to the
-//     following middleware or the final registered handler.
-//
-// Returns:
-//   - A wrapped EventHandler that intercepts event handling.
-//
-// Notes:
-//   - The first middleware passed to Use() is the outermost wrapper and executes first for each event.
+// EventHandlerMiddleware decorates an event handler on an [EventBus] with a
+// cross-cutting concern such as logging, telemetry, or error handling. It
+// receives the next handler in the chain and returns a handler that wraps
+// it; call next to pass the event along, or return without calling it to
+// short-circuit. Middleware is applied when a handler is passed to
+// [EventBus.Subscribe], and the first middleware passed to
+// [EventBus.Use] is the outermost wrapper and runs first for each event.
 //
 // Example Usage:
 //
@@ -147,18 +147,11 @@ func wrapQueryHandler[T Query, R any](h QueryHandler[T, R], middlewares []QueryH
 //	}
 type EventHandlerMiddleware func(next EventHandler) EventHandler
 
-// EventStoreMiddleware defines a function type for decorating an EventStore.
-// Apply one by wrapping a store directly: store = mw(store).
-//
-// Parameters:
-//   - next: The next EventStore in the chain. Delegate calls to it to preserve the
-//     original store's behaviour.
-//
-// Returns:
-//   - A decorated EventStore that intercepts one or more store operations.
-//
-// Notes:
-//   - A common implementation embeds EventStore and overrides only the methods of interest.
+// EventStoreMiddleware decorates an [EventStore], typically to intercept one
+// or more of its methods while delegating the rest to next. Apply one by
+// wrapping a store directly: store = mw(store). A common implementation
+// embeds EventStore for the pass-through methods and overrides only the
+// ones of interest.
 //
 // Example Usage:
 //

--- a/otel/command_handler.go
+++ b/otel/command_handler.go
@@ -13,10 +13,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// CommandTelemetry returns a CommandHandlerMiddleware that instruments every command
-// dispatched through the bus with OpenTelemetry tracing and metrics.
-// Use with bus.Use() to apply telemetry to all registered handlers.
-// The command type name is resolved at dispatch time from the concrete type.
+// CommandTelemetry returns an [eventsourcing.CommandHandlerMiddleware] that
+// instruments every command dispatched through the bus with OpenTelemetry
+// tracing and metrics. Use it with [eventsourcing.CommandBus.Use] to apply
+// telemetry to all registered handlers; the command type name is resolved at
+// dispatch time from the concrete type.
 func CommandTelemetry(options ...Option) eventsourcing.CommandHandlerMiddleware {
 	cfg := &config{}
 	for _, o := range options {
@@ -99,42 +100,18 @@ func CommandTelemetry(options ...Option) eventsourcing.CommandHandlerMiddleware 
 	}
 }
 
-// WithCommandTelemetry wraps a CommandHandler with OpenTelemetry tracing and metrics.
+// WithCommandTelemetry wraps next with OpenTelemetry tracing and metrics,
+// returning an [eventsourcing.CommandHandler] of the same type that can be
+// used as a drop-in replacement.
 //
-// This decorator observes the execution of a command handler, producing both
-// tracing spans and metrics that reflect command lifecycle, success/failure,
-// concurrency conflicts, and processing duration.
-//
-// The wrapper performs the following steps for each command execution:
-//  1. Starts a span for the command handling operation, named based on the command type.
-//  2. Attaches base attributes such as command type and aggregate ID.
-//  3. Increments the in-flight command metric before execution and decrements it after completion.
-//  4. Invokes the underlying command handler.
-//  5. Updates span attributes and metrics based on the handler's result:
-//     - Sets the stream ID attribute from the AppendResult.
-//     - Records command duration metric.
-//     - Updates span status (OK or Error).
-//     - Emits metrics for handled commands, failed commands, and concurrency conflicts.
-//
-// Parameters:
-//   - next: The underlying CommandHandler to be wrapped. It must return an AppendResult
-//     containing at least the StreamID and NextExpectedVersion.
-//
-// Returns:
-//   - A CommandHandler of the same type that automatically instruments tracing and metrics.
-//
-// Behavior Details:
-//   - The span is started with SpanKindInternal.
-//   - Base attributes include the command type and aggregate ID; the stream ID is appended after handler execution.
-//   - Metrics recorded:
-//   - CommandsProcessing: increments/decrements in-flight commands.
-//   - CommandsDuration: duration of command handling in seconds.
-//   - CommandsCount: total commands, labelled with eventsourcing.result=success|failure.
-//   - ConcurrencyConflicts: detected StreamRevisionConflictError occurrences.
-//   - Span attributes updated after execution include stream ID and stream version.
-//   - Span status is set to codes.Ok if the command succeeded, or codes.Error if an error occurred.
-//
-// Example Usage:
+// Each call to the returned handler starts a span covering the full
+// invocation of next, tagged with the command type and aggregate ID and, once
+// next returns, with the resulting stream ID and version. It also records
+// [CommandsProcessing] (in-flight commands), [CommandsDuration], and
+// [CommandsCount] labelled by [AttrResult]. A returned
+// [eventsourcing.StreamRevisionConflictError] is additionally counted in
+// [ConcurrencyConflicts]; a returned [eventsourcing.ErrBusinessRuleViolation]
+// is recorded on the span as an expected outcome rather than a span error.
 //
 //	handler := WithCommandTelemetry(myCommandHandler)
 //	result, err := handler(ctx, myCommand)

--- a/otel/config.go
+++ b/otel/config.go
@@ -6,26 +6,29 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 )
 
-// config holds the options for tracing an endpoint.
+// config holds the telemetry options for a single wrapped endpoint, built up
+// from the [Option] values passed to a constructor such as
+// [WithCommandTelemetry] or [WithEventStoreTelemetry].
 type config struct {
-	// Operation identifies the current operation and serves as a span name.
+	// Operation is the default span name for the endpoint.
 	Operation string
 
-	// GetOperation is an optional function that can set the span name based on the existing operation
-	// for the endpoint and information in the context.
-	//
-	// If the function is nil, or the returned operation is empty, the existing operation for the endpoint is used.
+	// GetOperation, if non-nil, derives the span name from the context and
+	// the existing operation name. If it returns an empty string, the
+	// existing operation name is used instead.
 	GetOperation func(ctx context.Context, operation string) string
 
-	// Attributes holds the default attributes for each span created by this middleware.
+	// Attributes are added to every span created for the endpoint.
 	Attributes []attribute.KeyValue
 
-	// GetAttributes is an optional function that can extract trace attributes
-	// from the context and add them to the span.
+	// GetAttributes, if non-nil, is called for each span to derive
+	// additional attributes from the context.
 	GetAttributes func(ctx context.Context) []attribute.KeyValue
 }
 
-// Option configures an EndpointMiddleware.
+// Option configures the telemetry behavior of a wrapper such as
+// [WithCommandTelemetry], [WithQueryTelemetry], [WithEventBusTelemetry], or
+// [WithEventStoreTelemetry].
 type Option interface {
 	apply(*config)
 }
@@ -36,29 +39,32 @@ func (o optionFunc) apply(c *config) {
 	o(c)
 }
 
-// WithOperation sets an operation name for an endpoint.
-// Use this when you register a middleware for each endpoint.
+// WithOperation sets a fixed span name for the wrapped endpoint, overriding
+// the package's default naming.
 func WithOperation(operation string) Option {
 	return optionFunc(func(o *config) {
 		o.Operation = operation
 	})
 }
 
-// WithOperationGetter sets an operation name getter function in config.
+// WithOperationGetter sets a function that derives the span name at call
+// time from the context and the endpoint's current operation name.
 func WithOperationGetter(fn func(ctx context.Context, name string) string) Option {
 	return optionFunc(func(o *config) {
 		o.GetOperation = fn
 	})
 }
 
-// WithAttributes sets the default attributes for the spans created by the Endpoint tracer.
+// WithAttributes sets attributes to add to every span created by the
+// wrapped endpoint.
 func WithAttributes(attrs ...attribute.KeyValue) Option {
 	return optionFunc(func(o *config) {
 		o.Attributes = attrs
 	})
 }
 
-// WithAttributeGetter extracts additional attributes from the context.
+// WithAttributeGetter sets a function that derives additional span
+// attributes from the context at call time.
 func WithAttributeGetter(fn func(ctx context.Context) []attribute.KeyValue) Option {
 	return optionFunc(func(o *config) {
 		o.GetAttributes = fn

--- a/otel/event_bus.go
+++ b/otel/event_bus.go
@@ -16,52 +16,26 @@ import (
 
 var _ eventsourcing.EventBus = (*TelemetryEventBus)(nil)
 
-// TelemetryEventBus wraps an EventBus with OpenTelemetry tracing and metrics.
-//
-// This decorator intercepts event subscriptions to automatically instrument
-// event handlers with distributed tracing and metrics collection. It creates
-// a consumer span per received event that links back to the original producer
-// trace, enabling end-to-end distributed tracing from command execution through
-// event processing.
+// TelemetryEventBus wraps an [eventsourcing.EventBus], instrumenting every
+// subscription registered through it with OpenTelemetry tracing and metrics.
+// For each received event it starts a consumer span linked back to the
+// original producer trace, enabling end-to-end distributed tracing from
+// command execution through event processing. Construct one with
+// [WithEventBusTelemetry].
 type TelemetryEventBus struct {
 	next eventsourcing.EventBus
 	cfg  *config
 }
 
-// Subscribe registers an event handler wrapped with telemetry instrumentation.
-//
-// For each received event the wrapper:
-//  1. Extracts trace context from event metadata to establish distributed trace links.
-//  2. Creates a consumer span named "receive subscription" with event attributes.
-//  3. Links the span to the original producer trace for correlation.
-//  4. Increments the EventBusHandled metric.
-//  5. Invokes the underlying event handler.
-//  6. Records the EventBusDuration metric with processing time.
-//  7. Updates span status based on handler result:
-//     - ErrSkippedEvent: span status OK (intentional skip)
-//     - Other errors: span status Error, increments EventBusErrors metric
-//     - Success: span status OK
-//
-// Parameters:
-//   - ctx: Context for the subscription setup.
-//   - name: Unique identifier for this subscription, used in span attributes.
-//   - next: The event handler to be wrapped with telemetry instrumentation.
-//   - options: Optional subscriber configuration options passed to the underlying bus.
-//
-// Returns:
-//   - An error if the subscription registration fails.
-//
-// Behavior Details:
-//   - The span uses SpanKindConsumer to indicate event consumption.
-//   - Trace links connect the consumer span to the original command/producer trace.
-//   - Metrics recorded:
-//   - EventBusHandled: count of events received by this subscription.
-//   - EventBusDuration: handler execution time in seconds.
-//   - EventBusErrors: count of handler errors (excludes ErrSkippedEvent).
-//   - Span attributes include event type, event ID, global position, stream position,
-//     stream ID, and subscriber name.
-//
-// Example Usage:
+// Subscribe registers next under name on the underlying bus, wrapping it so
+// each received event is handled inside a consumer span linked to the
+// original producer trace (recovered from the event's metadata). The span is
+// tagged with the event type, event ID, global and stream position, stream
+// ID, and subscriber name; [EventBusHandled] and [EventBusDuration] are
+// recorded for every invocation, and [EventBusErrors] for every error other
+// than [eventsourcing.ErrSkippedEvent], which is treated as an intentional,
+// non-error skip. It returns an error if the underlying bus fails to
+// register the subscription.
 //
 //	bus := otel.WithEventBusTelemetry(eventBus)
 //	err := bus.Subscribe(ctx, "order-projector", orderProjector)
@@ -136,45 +110,31 @@ func (t *TelemetryEventBus) Subscribe(ctx context.Context, name string, next eve
 
 }
 
-// Errors returns the error channel from the underlying event bus.
-//
-// This method delegates directly to the wrapped EventBus without additional
-// instrumentation, as errors are already tracked at the handler level.
+// Use delegates to the underlying [eventsourcing.EventBus], adding
+// middlewares to the chain applied to its subscribers.
 func (t *TelemetryEventBus) Use(middlewares ...eventsourcing.EventHandlerMiddleware) {
 	t.next.Use(middlewares...)
 }
 
+// Errors returns the error channel from the underlying event bus. This
+// method delegates directly to the wrapped [eventsourcing.EventBus] without
+// additional instrumentation, since errors are already tracked at the
+// handler level in [TelemetryEventBus.Subscribe].
 func (t *TelemetryEventBus) Errors() <-chan error {
 	return t.next.Errors()
 }
 
-// Close closes the underlying event bus and waits for all handlers to finish.
-//
-// This method delegates directly to the wrapped EventBus without additional
-// instrumentation.
+// Close closes the underlying event bus and waits for all handlers to
+// finish. This method delegates directly to the wrapped
+// [eventsourcing.EventBus] without additional instrumentation.
 func (t *TelemetryEventBus) Close() error {
 	return t.next.Close()
 }
 
-// WithEventBusTelemetry wraps an EventBus with OpenTelemetry tracing and metrics.
-//
-// This constructor creates a TelemetryEventBus that decorates all subscriptions
-// with automatic tracing spans and metrics collection. The wrapper preserves
-// distributed trace context by extracting trace information from event metadata
-// and linking consumer spans to the original producer traces.
-//
-// Parameters:
-//   - next: The underlying EventBus to be wrapped.
-//   - options: Optional configuration for customizing telemetry behavior:
-//   - WithAttributes: adds static attributes to all spans.
-//   - WithAttributeGetter: adds dynamic attributes from context.
-//   - WithOperation: customizes the span operation name.
-//   - WithOperationGetter: dynamically customizes span names.
-//
-// Returns:
-//   - A TelemetryEventBus that implements the EventBus interface with telemetry.
-//
-// Example Usage:
+// WithEventBusTelemetry wraps next in a [TelemetryEventBus], instrumenting
+// every subscription registered through it with OpenTelemetry tracing and
+// metrics. See [TelemetryEventBus.Subscribe] for what is recorded; options
+// such as [WithAttributes] and [WithOperation] customize the spans produced.
 //
 //	bus := otel.WithEventBusTelemetry(eventBus,
 //	    otel.WithAttributes(attribute.String("service", "orders")),
@@ -192,9 +152,11 @@ func WithEventBusTelemetry(next eventsourcing.EventBus, options ...Option) *Tele
 	}
 }
 
-// EventBusTelemetry returns an EventHandlerMiddleware that instruments event
-// handlers subscribed through the bus with OpenTelemetry tracing and metrics.
-// Use with NewMiddlewareEventBus().Use() to apply telemetry to all subscribers.
+// EventBusTelemetry returns an [eventsourcing.EventHandlerMiddleware] that
+// instruments event handlers with OpenTelemetry tracing and metrics; it
+// wraps each handler with [WithEventTelemetry]. Pass it to an
+// [eventsourcing.EventBus] implementation's Use method to apply telemetry to
+// all subscribers registered afterward.
 func EventBusTelemetry(options ...Option) eventsourcing.EventHandlerMiddleware {
 	return func(next eventsourcing.EventHandler) eventsourcing.EventHandler {
 		return WithEventTelemetry(next, options...)

--- a/otel/event_handler.go
+++ b/otel/event_handler.go
@@ -14,7 +14,20 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// TODO extract the consumer group
+// WithEventTelemetry wraps next with OpenTelemetry tracing and metrics,
+// returning an [eventsourcing.EventHandler] that can be used as a drop-in
+// replacement.
+//
+// Each call starts a span linked to the original producer trace (recovered
+// from the event's metadata), tagged with the event type, event ID, global
+// and stream position, and stream ID. It records [EventBusHandled] and
+// [EventBusDuration] for every invocation. A returned
+// [eventsourcing.ErrSkippedEvent] is treated as an intentional, non-error
+// skip and marks the span OK, while any other error marks the span as
+// failed; unlike [TelemetryEventBus.Subscribe], it does not record
+// [EventBusErrors].
+//
+// TODO: extract the consumer group.
 func WithEventTelemetry(next eventsourcing.EventHandler, options ...Option) eventsourcing.EventHandler {
 	cfg := &config{}
 
@@ -79,6 +92,9 @@ func WithEventTelemetry(next eventsourcing.EventHandler, options ...Option) even
 			if errors.As(err, &skipped) {
 				span.SetStatus(codes.Ok, "")
 			} else {
+				// TODO: TelemetryEventBus.Subscribe increments EventBusErrors
+				// here; this path does not. Confirm whether that's
+				// intentional or a gap.
 				span.SetStatus(codes.Error, err.Error())
 				span.RecordError(err)
 			}

--- a/otel/event_store.go
+++ b/otel/event_store.go
@@ -16,11 +16,18 @@ import (
 
 var _ eventsourcing.EventStore = (*TelemetryStore)(nil)
 
+// TelemetryStore wraps an [eventsourcing.EventStore], instrumenting every
+// save and load operation with OpenTelemetry tracing and metrics and
+// injecting trace propagation headers into appended events' metadata.
+// Construct one with [WithEventStoreTelemetry].
 type TelemetryStore struct {
 	next eventsourcing.EventStore
 	cfg  *config
 }
 
+// baseAttrs returns the span attributes common to every operation: the
+// configured db.system attribute (defaulting to "eventsourcing") followed by
+// any other attributes from cfg.
 func (t TelemetryStore) baseAttrs() []attribute.KeyValue {
 	dbSystem := "eventsourcing"
 	for _, kv := range t.cfg.Attributes {
@@ -37,7 +44,15 @@ func (t TelemetryStore) baseAttrs() []attribute.KeyValue {
 	return attrs
 }
 
-// Save with metrics + span
+// Save appends events to the underlying [eventsourcing.EventStore] inside a
+// client span tagged with the stream ID and requested revision. Before
+// saving, it stamps each event's Metadata with the current trace's
+// causation ID (from [eventsourcing.CausationFromContext]), correlation ID
+// (the trace ID, if the span has one), and injected trace-propagation
+// headers, so a later [TelemetryEventBus] or event handler can link back to
+// this trace. It records [EventStoreDuration], [EventStoreSaves], and
+// [EventsAppended] for every call, and [EventStoreErrors] if the underlying
+// store returns an error.
 func (t TelemetryStore) Save(ctx context.Context, events []eventsourcing.Envelope, revision eventsourcing.StreamState) (eventsourcing.AppendResult, error) {
 	var streamID string
 	for _, event := range events {
@@ -102,7 +117,13 @@ func (t TelemetryStore) Save(ctx context.Context, events []eventsourcing.Envelop
 	return result, err
 }
 
-// LoadStream with inline tracing middleware
+// LoadStream loads the stream id from the underlying
+// [eventsourcing.EventStore]. If the initial call fails, it records
+// [EventStoreErrors] and returns immediately. Otherwise it returns an
+// iterator that, on its first advance, starts a client span tagged with the
+// stream ID; each yielded event increments [EventsLoaded], and
+// [EventStoreDuration] is recorded, and [EventStoreErrors] incremented on
+// failure, once the iterator is exhausted.
 func (t TelemetryStore) LoadStream(ctx context.Context, id string) (*eventsourcing.Iterator[*eventsourcing.Envelope], error) {
 	iter, err := t.next.LoadStream(ctx, id)
 	if err != nil {
@@ -153,7 +174,10 @@ func (t TelemetryStore) LoadStream(ctx context.Context, id string) (*eventsourci
 	}), nil
 }
 
-// LoadStreamFrom with inline tracing middleware
+// LoadStreamFrom loads stream id from version onward from the underlying
+// [eventsourcing.EventStore]. It behaves like [TelemetryStore.LoadStream],
+// additionally tagging the span with the requested version and, once the
+// iterator is exhausted, with the number of events yielded.
 func (t TelemetryStore) LoadStreamFrom(ctx context.Context, id string, version eventsourcing.StreamState) (*eventsourcing.Iterator[*eventsourcing.Envelope], error) {
 	iter, err := t.next.LoadStreamFrom(ctx, id, version)
 	if err != nil {
@@ -208,7 +232,10 @@ func (t TelemetryStore) LoadStreamFrom(ctx context.Context, id string, version e
 	}), nil
 }
 
-// LoadFromAll with inline tracing middleware
+// LoadFromAll loads all events across streams from version onward from the
+// underlying [eventsourcing.EventStore]. It behaves like
+// [TelemetryStore.LoadStream], tagging the span with the requested version
+// instead of a stream ID, since the events may belong to any stream.
 func (t TelemetryStore) LoadFromAll(ctx context.Context, version eventsourcing.StreamState) (*eventsourcing.Iterator[*eventsourcing.Envelope], error) {
 	iter, err := t.next.LoadFromAll(ctx, version)
 	if err != nil {
@@ -263,12 +290,16 @@ func (t TelemetryStore) LoadFromAll(ctx context.Context, version eventsourcing.S
 	}), nil
 }
 
-// Close just forwards
+// Close closes the underlying [eventsourcing.EventStore]. It delegates
+// directly, without additional instrumentation.
 func (t TelemetryStore) Close() error {
 	return t.next.Close()
 }
 
-// WithEventStoreTelemetry wraps an EventStore with OpenTelemetry tracing and metrics.
+// WithEventStoreTelemetry wraps next in a [TelemetryStore], instrumenting
+// every save and load with OpenTelemetry tracing and metrics as described on
+// [TelemetryStore]. Options such as [WithAttributes] and [WithOperation]
+// customize the spans produced.
 func WithEventStoreTelemetry(next eventsourcing.EventStore, options ...Option) eventsourcing.EventStore {
 	cfg := &config{}
 	for _, o := range options {
@@ -277,9 +308,11 @@ func WithEventStoreTelemetry(next eventsourcing.EventStore, options ...Option) e
 	return TelemetryStore{next: next, cfg: cfg}
 }
 
-// EventStoreTelemetry returns an EventStoreMiddleware that instruments the store
-// with OpenTelemetry tracing and metrics.
-// Apply it by wrapping a store directly: store = EventStoreTelemetry()(store).
+// EventStoreTelemetry returns an [eventsourcing.EventStoreMiddleware] that
+// instruments an [eventsourcing.EventStore] with OpenTelemetry tracing and
+// metrics; it wraps the store with [WithEventStoreTelemetry].
+//
+//	store = otel.EventStoreTelemetry()(store)
 func EventStoreTelemetry(options ...Option) eventsourcing.EventStoreMiddleware {
 	return func(next eventsourcing.EventStore) eventsourcing.EventStore {
 		return WithEventStoreTelemetry(next, options...)

--- a/otel/otel.go
+++ b/otel/otel.go
@@ -12,9 +12,11 @@ const (
 	instrumentationName = "github.com/terraskye/eventsourcing"
 )
 
-// Semantic attribute keys following OpenTelemetry conventions
+// Semantic attribute keys used on the spans and metrics produced by this
+// package, following OpenTelemetry naming conventions.
 const (
-	// Database attributes (OpenTelemetry semantic conventions)
+	// AttrDBSystem identifies the database system, following the OpenTelemetry
+	// semantic conventions.
 	AttrDBSystem = attribute.Key("db.system")
 
 	// Command attributes
@@ -58,17 +60,30 @@ const (
 	AttrQueueDepth   = attribute.Key("eventsourcing.queue.depth")
 )
 
+// meter and tracer are the shared OpenTelemetry instruments used by every
+// telemetry wrapper in this package; all spans and metrics are reported
+// under instrumentationName.
 var (
 	meter  = otel.Meter(instrumentationName, metric.WithInstrumentationVersion(eventsourcing.InstrumentationVersion))
 	tracer = otel.Tracer(instrumentationName, trace.WithInstrumentationVersion(eventsourcing.InstrumentationVersion))
+)
 
+// Metric instruments recorded by the telemetry wrappers in this package.
+// They are exported so callers can read their descriptors (name, unit,
+// description) when wiring up custom views or exporters; they are not meant
+// to be recorded to directly.
+var (
 	// Command metrics
+
+	// CommandsCount counts commands handled, labelled by
+	// [AttrResult] ("success" or "failure").
 	CommandsCount, _ = meter.Int64Counter(
 		"eventsourcing.commands.count",
 		metric.WithDescription("Total number of commands handled, labelled by eventsourcing.result"),
 		metric.WithUnit("{command}"),
 	)
 
+	// CommandsDuration records command handling duration, in seconds.
 	CommandsDuration, _ = meter.Float64Histogram(
 		"eventsourcing.commands.duration",
 		metric.WithDescription("Command handling duration"),
@@ -76,6 +91,8 @@ var (
 		metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10),
 	)
 
+	// CommandsProcessing tracks the number of commands currently being
+	// processed.
 	CommandsProcessing, _ = meter.Int64UpDownCounter(
 		"eventsourcing.command.processing",
 		metric.WithDescription("Number of commands currently being processed"),
@@ -83,12 +100,15 @@ var (
 	)
 
 	// EventData metrics
+
+	// EventsAppended counts events appended to streams.
 	EventsAppended, _ = meter.Int64Counter(
 		"eventsourcing.events.appended",
 		metric.WithDescription("Number of events appended to streams"),
 		metric.WithUnit("{event}"),
 	)
 
+	// EventsLoaded counts events loaded from streams.
 	EventsLoaded, _ = meter.Int64Counter(
 		"eventsourcing.events.loaded",
 		metric.WithDescription("Number of events loaded from streams"),
@@ -96,18 +116,22 @@ var (
 	)
 
 	// EventBus metrics
+
+	// EventBusHandled counts events handled by subscribers.
 	EventBusHandled, _ = meter.Int64Counter(
 		"eventsourcing.eventbus.handled",
 		metric.WithDescription("Number of events handled by subscribers"),
 		metric.WithUnit("{event}"),
 	)
 
+	// EventBusErrors counts event bus handler errors.
 	EventBusErrors, _ = meter.Int64Counter(
 		"eventsourcing.eventbus.errors",
 		metric.WithDescription("Number of event bus handler errors"),
 		metric.WithUnit("{error}"),
 	)
 
+	// EventBusDuration records event bus handler duration, in seconds.
 	EventBusDuration, _ = meter.Float64Histogram(
 		"eventsourcing.eventbus.duration",
 		metric.WithDescription("Event bus handler duration"),
@@ -116,12 +140,16 @@ var (
 	)
 
 	// Query metrics
+
+	// QueriesCount counts queries handled, labelled by [AttrResult]
+	// ("success" or "failure").
 	QueriesCount, _ = meter.Int64Counter(
 		"eventsourcing.queries.count",
 		metric.WithDescription("Total number of queries handled, labelled by eventsourcing.result"),
 		metric.WithUnit("{query}"),
 	)
 
+	// QueriesDuration records query handling duration, in seconds.
 	QueriesDuration, _ = meter.Float64Histogram(
 		"eventsourcing.queries.duration",
 		metric.WithDescription("Query handling duration"),
@@ -129,6 +157,8 @@ var (
 		metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5),
 	)
 
+	// QueriesProcessing tracks the number of queries currently being
+	// processed.
 	QueriesProcessing, _ = meter.Int64UpDownCounter(
 		"eventsourcing.query.processing",
 		metric.WithDescription("Number of queries currently being processed"),
@@ -136,12 +166,15 @@ var (
 	)
 
 	// EventStore metrics
+
+	// EventStoreSaves counts EventStore save operations.
 	EventStoreSaves, _ = meter.Int64Counter(
 		"eventsourcing.eventstore.saves",
 		metric.WithDescription("Number of save operations"),
 		metric.WithUnit("{operation}"),
 	)
 
+	// EventStoreDuration records EventStore operation duration, in seconds.
 	EventStoreDuration, _ = meter.Float64Histogram(
 		"eventsourcing.eventstore.duration",
 		metric.WithDescription("Event store operation duration"),
@@ -149,6 +182,7 @@ var (
 		metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5),
 	)
 
+	// EventStoreErrors counts EventStore errors.
 	EventStoreErrors, _ = meter.Int64Counter(
 		"eventsourcing.eventstore.errors",
 		metric.WithDescription("Number of event store errors"),
@@ -156,6 +190,9 @@ var (
 	)
 
 	// System metrics
+
+	// ConcurrencyConflicts counts detected
+	// [eventsourcing.StreamRevisionConflictError] occurrences.
 	ConcurrencyConflicts, _ = meter.Int64Counter(
 		"eventsourcing.concurrency.conflicts",
 		metric.WithDescription("Number of concurrency conflicts"),

--- a/otel/query_handler.go
+++ b/otel/query_handler.go
@@ -12,10 +12,11 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// QueryTelemetry returns a QueryHandlerMiddleware that instruments every query dispatched
-// through the bus with OpenTelemetry tracing and metrics.
-// Use with bus.Use() to apply telemetry to all registered handlers.
-// The query type name is resolved at dispatch time from the concrete type.
+// QueryTelemetry returns an [eventsourcing.QueryHandlerMiddleware] that
+// instruments every query dispatched through the bus with OpenTelemetry
+// tracing and metrics. Use it with [eventsourcing.QueryBus.Use] to apply
+// telemetry to all registered handlers; the query type name is resolved at
+// dispatch time from the concrete type.
 func QueryTelemetry(options ...Option) eventsourcing.QueryHandlerMiddleware {
 	cfg := &config{}
 	for _, o := range options {
@@ -74,23 +75,14 @@ func QueryTelemetry(options ...Option) eventsourcing.QueryHandlerMiddleware {
 	}
 }
 
-// WithQueryTelemetry wraps a QueryHandler with OpenTelemetry tracing and metrics.
+// WithQueryTelemetry wraps next with OpenTelemetry tracing and metrics,
+// returning an [eventsourcing.QueryHandler] of the same type that can be
+// used as a drop-in replacement.
 //
-// This decorator observes the execution of a query handler, producing both
-// tracing spans and metrics that reflect query lifecycle, success/failure,
-// and processing duration.
-//
-// The wrapper performs the following steps for each query execution:
-//  1. Starts a span for the query handling operation, named based on the query type.
-//  2. Attaches base attributes such as query type and query ID.
-//  3. Increments the in-flight query metric before execution and decrements it after completion.
-//  4. Invokes the underlying query handler.
-//  5. Updates span attributes and metrics based on the handler's result:
-//     - Records query duration metric.
-//     - Updates span status (OK or Error).
-//     - Emits metrics for handled queries and failed queries.
-//
-// Example Usage:
+// Each call to the returned handler's HandleQuery starts a span covering the
+// full invocation of next, tagged with the query type and query ID. It also
+// records [QueriesProcessing] (in-flight queries), [QueriesDuration], and
+// [QueriesCount] labelled by [AttrResult].
 //
 //	handler := WithQueryTelemetry(myQueryHandler)
 //	result, err := handler.HandleQuery(ctx, myQuery)

--- a/query_bus.go
+++ b/query_bus.go
@@ -6,11 +6,10 @@ import (
 	"sync"
 )
 
-// QueryBus acts as a central registry for query handlers. It stores
-// handlers keyed by their query and result types, allowing multiple
-// query types to be registered in a single bus.
-//
-// Handlers can later be executed via a typed GenericQueryGateway.
+// QueryBus is a central registry of query handlers, keyed by their query
+// and result types, so that multiple query types can be registered on a
+// single bus. Handlers are executed through a typed [QueryGateway] created
+// with [NewQueryGateway].
 //
 // Example Usage:
 //
@@ -83,6 +82,11 @@ func RegisterQueryHandler[T Query, R any](bus *QueryBus, handler QueryHandler[T,
 	}
 }
 
+// Validate reports an error listing every query/result type pair that a
+// [QueryGateway] was created for via [NewQueryGateway] but that has no
+// registered handler. Call it during startup, after all gateways and
+// handlers are wired up, to catch a missing registration before it can
+// surface as a runtime error.
 func (q *QueryBus) Validate() error {
 	errs := make([]error, 0)
 	for requestee := range q.requestees {

--- a/query_gateway.go
+++ b/query_gateway.go
@@ -5,14 +5,10 @@ import (
 	"fmt"
 )
 
-// QueryGateway is a typed, callable facade over QueryBus. Call it directly
-// like a function to execute the registered handler for query type T.
-// It also implements QueryHandler[T, R], so it can be passed to decorators
-// such as WithQueryTelemetry or WithQueryLogging.
-//
-// Type Parameters:
-//   - T: The query type implementing Query.
-//   - R: The result type.
+// QueryGateway is a typed, callable facade over a [QueryBus]. Call it
+// directly like a function to execute the handler registered for query type
+// T and result type R. It also implements [QueryHandler], so it can be
+// passed to decorators such as WithQueryTelemetry or WithQueryLogging.
 //
 // Example Usage:
 //
@@ -20,19 +16,20 @@ import (
 //	result, err := gateway(ctx, MyQuery{ID: "42"})
 type QueryGateway[T Query, R any] func(ctx context.Context, qry T) (R, error)
 
-// HandleQuery implements QueryHandler[T, R].
+// HandleQuery implements [QueryHandler] by calling g.
 func (g QueryGateway[T, R]) HandleQuery(ctx context.Context, qry T) (R, error) {
 	return g(ctx, qry)
 }
 
-// GenericQueryGateway is a backwards-compatible alias for QueryGateway.
+// GenericQueryGateway is a backwards-compatible alias for [QueryGateway].
 //
 // Deprecated: use QueryGateway directly.
 type GenericQueryGateway[T Query, R any] = QueryGateway[T, R]
 
-// NewQueryGateway creates a QueryGateway for a specific query and result type
-// backed by a QueryBus. Creating a gateway registers the (T, R) pair as a
-// requestee, which is checked by bus.Validate() at startup.
+// NewQueryGateway returns a [QueryGateway] for query type T and result type
+// R, backed by bus. It registers the (T, R) pair on bus as a requestee, so
+// that a later call to [QueryBus.Validate] fails if no handler for that pair
+// is ever registered.
 //
 // Example Usage:
 //

--- a/query_handler.go
+++ b/query_handler.go
@@ -4,18 +4,17 @@ import (
 	"context"
 )
 
-// Query is the interface that must be implemented by any type to be considered a query.
+// Query is implemented by any type that can be handled by a [QueryHandler].
 type Query interface {
+	// ID returns an identifier for this query occurrence, for example for
+	// correlation in logs or traces.
 	ID() []byte
 }
 
-// QueryHandler represents a handler for a specific query type T and
-// produces a result of type R. This interface allows generic, type-safe
-// registration and execution of query logic.
-//
-// Type Parameters:
-//   - T: The query type implementing Query.
-//   - R: The return type, either a single ReadModel or an Iterator.
+// QueryHandler handles queries of the concrete type T, which must implement
+// [Query], and produces a result of type R — typically a read model or an
+// [Iterator] over one. It enables generic, type-safe registration and
+// execution of query logic through a [QueryBus].
 //
 // Example Usage:
 //
@@ -31,14 +30,8 @@ type QueryHandler[T Query, R any] interface {
 	HandleQuery(ctx context.Context, qry T) (R, error)
 }
 
-// queryHandlerFunc is a helper type to allow ordinary functions to
-// implement QueryHandler[T,R].
-//
-// Example Usage:
-//
-//	handler := NewQueryHandlerFunc(func(ctx context.Context, q MyQuery) (*MyResult, error) {
-//	    return &MyResult{Value: 42}, nil
-//	})
+// queryHandlerFunc adapts an ordinary function to implement
+// QueryHandler[T, R].
 type queryHandlerFunc[T Query, R any] func(ctx context.Context, qry T) (R, error)
 
 // HandleQuery calls the underlying function.
@@ -46,13 +39,7 @@ func (f queryHandlerFunc[T, R]) HandleQuery(ctx context.Context, qry T) (R, erro
 	return f(ctx, qry)
 }
 
-// NewQueryHandlerFunc creates a QueryHandler from a function.
-//
-// Parameters:
-//   - fn: The function to wrap as a QueryHandler.
-//
-// Returns:
-//   - QueryHandler[T,R]: A handler that implements QueryHandler interface.
+// NewQueryHandlerFunc returns fn as a [QueryHandler].
 //
 // Example Usage:
 //

--- a/revision.go
+++ b/revision.go
@@ -1,25 +1,33 @@
 package eventsourcing
 
+// StreamState expresses a caller's expectation of a stream's revision, for
+// example to an [EventStore.Save] call via [WithStreamState]. [Any],
+// [NoStream], [StreamExists], and [Revision] are the implementations
+// recognized by this package's EventStore implementations.
 type StreamState interface {
+	// ToRawInt64 encodes the expectation as a store-specific raw value: a
+	// non-negative [Revision] number, or one of the special negative
+	// markers used by [Any] and [StreamExists].
 	ToRawInt64() int64
 }
 
-// Any means append without checking current revision.
+// Any expects nothing: append without checking the stream's current
+// revision.
 type Any struct{}
 
 func (Any) ToRawInt64() int64 { return -1 } // special marker
 
-// NoStream means the stream should not exist yet.
+// NoStream expects the stream not to exist yet.
 type NoStream struct{}
 
 func (NoStream) ToRawInt64() int64 { return 0 }
 
-// StreamExists means the stream must exist.
+// StreamExists expects the stream to already exist.
 type StreamExists struct{}
 
 func (StreamExists) ToRawInt64() int64 { return -2 } // special marker
 
-// Revision matches exactly a numeric revision.
+// Revision expects the stream to be at exactly this version.
 type Revision uint64
 
 func (r Revision) ToRawInt64() int64 { return int64(r) }

--- a/stringer.go
+++ b/stringer.go
@@ -5,7 +5,8 @@ import (
 	"strings"
 )
 
-// TypeName returns the struct name without the package path
+// TypeName returns t's concrete type name, without its package path or any
+// leading pointer asterisk.
 func TypeName[T any](t T) string {
 	segments := strings.Split(fmt.Sprintf("%T", t), ".")
 	return segments[len(segments)-1] // Get only the struct name

--- a/version.go
+++ b/version.go
@@ -1,5 +1,7 @@
 package eventsourcing
 
+// InstrumentationVersion is the module version reported as the
+// instrumentation version of this package's OpenTelemetry meter and tracer.
 const (
 	InstrumentationVersion = "v0.1.0"
 )


### PR DESCRIPTION
## Summary

Applies this repo's `.claude/skills/go-doc` conventions across the whole module: root package plus `otel/`, `logging/`, `eventbus/*`, and `eventstore/*`. No behavior changes — comments only, plus a handful of `// TODO:` markers left where a comment turned out to describe behavior the code doesn't actually implement.

- Converted every Javadoc-style `Parameters:`/`Returns:`/`Notes:`/`Behavior Details:` block (none of which are real godoc headings) into prose.
- Gave every exported declaration a complete opening sentence naming its own subject, and wrapped referenced symbols in `[brackets]` for doc links.
- Moved `Iterator`'s inline usage example into a testable `ExampleNewIteratorFunc` (`iter_test.go`).

### Doc/code mismatches found and corrected

- `eventstore.go`'s `EventStore.Save` doc named a nonexistent `ErrConcurrency`; the real error is `StreamRevisionConflictError`.
- `command_handler.go`'s `CommandHandler` doc referenced a nonexistent `AppendResult.Events` field; `NewCommandHandler`'s doc named a `SeqWithSideEffect` wrapper and an `errors.Wrap` call that don't exist, plus a `RetryAttempts` option that isn't how retries work (it's a `backoff.BackOff` via `WithRetryStrategy`).
- `WithStreamState`'s example called a `WithRevision` function that doesn't exist.
- `event_bus.go` claimed `EventBus` "is an `EventHandler`" that lets "only one of each type" handle an event — it isn't an `EventHandler`, and every implementation fans out to all matching subscribers.
- `context.go` had two comments copy-pasted from the wrong function (`GlobalVersionFromContext`, `CausationFromContext`).
- `event_handler.go`'s `OnEvent` doc claimed `EventName()` derives its key via `TypeName[T]`, but it actually uses the unstripped `%T` form.

### Real bugs found, left as `// TODO:` rather than silently fixed

- `command_handler.go`: `Save` always persists against the originally configured revision, not the one observed while loading the stream during a retry.
- `eventstore/memory` and `eventstore/file`: `Close` isn't idempotent (a second call panics); `eventstore/file`'s `Save` can silently overwrite events on disk since it derives filenames from an `Envelope.Version` nothing sets before calling it; `eventstore/memory`'s `LoadFromAll` panics on `Any{}`/`StreamExists{}`.
- `eventstore/kurrentdb`: a returned `StreamRevisionConflictError` panics when formatted (its revision fields are left nil); several `Recv` errors are masked as clean `io.EOF` instead of propagated; `LoadFromAll` ignores its `version` parameter; an unused `buffer` constructor parameter implies behavior it doesn't have.
- `eventbus/file`: `Close` isn't idempotent either.
- `eventbus/kurrentdb`: `EnsurePersistentSubscription` silently swallows non-"not found" errors instead of propagating them.
- `otel`: `TelemetryEventBus.Subscribe` increments an error metric on handler failure that `WithEventTelemetry`'s equivalent path does not.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] `go test ./...` (145 passed, 11 packages)