### PR TITLE
Fix Iterator.Value() not resetting to zero value after completion

### DIFF
--- a/iter.go
+++ b/iter.go
@@ -47,6 +47,8 @@ func (it *Iterator[T]) Next(ctx context.Context) bool {
 
 	val, err := it.nextFunc(ctx)
 	if err != nil {
+		var zero T
+		it.current = zero
 		if err == io.EOF {
 			it.done = true
 			it.err = nil

--- a/iter_test.go
+++ b/iter_test.go
@@ -174,6 +174,21 @@ func TestIteratorValueZeroBeforeNext(t *testing.T) {
 	}
 }
 
+func TestIteratorValueZeroAfterCompletion(t *testing.T) {
+	iter := cqrs.NewSliceIterator([]int{1, 2, 3})
+
+	for iter.Next(t.Context()) {
+	}
+
+	if iter.Err() != nil {
+		t.Fatalf("unexpected error: %v", iter.Err())
+	}
+
+	if v := iter.Value(); v != 0 {
+		t.Fatalf("expected Value() to be zero after iteration completed, got %v", v)
+	}
+}
+
 func TestIteratorNoItems(t *testing.T) {
 	iter := cqrs.NewIteratorFunc(func(ctx context.Context) (int, error) {
 		return 0, io.EOF


### PR DESCRIPTION
## Summary
- `Next()` only wrote `it.current` on the success path, so once iteration ended via `io.EOF` or an error, `Value()` kept returning the last successfully produced item instead of the documented zero value.
- Reset `it.current` to the zero value of `T` in both failure branches of `Next()`.

Fixes #43

## Test plan
- [x] Added `TestIteratorValueZeroAfterCompletion` (the repro from the issue) — fails without the fix, passes with it
- [x] `go test -run 'TestIterator|ExampleNewIteratorFunc' -v .` — all pass
- [x] `go build ./...` and `go vet ./...` — clean