### PR TITLE
Add regression test for StreamRevisionConflictError.Error() with non-Revision StreamStates

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -24,6 +24,15 @@ func TestErrorStrings(t *testing.T) {
 			want: `concurrency conflict on stream "stream-123": (expected version 5, actual 7)`,
 		},
 		{
+			name: "StreamRevisionConflictError with non-Revision StreamStates",
+			err: StreamRevisionConflictError{
+				Stream:           "stream-123",
+				ExpectedRevision: Any{},
+				ActualRevision:   StreamExists{},
+			},
+			want: `concurrency conflict on stream "stream-123": (expected version -1, actual -2)`,
+		},
+		{
 			name: "ErrSkippedEvent",
 			err:  ErrSkippedEvent{Event: &event{}},
 			want: "skipped event of type *eventsourcing.event",


### PR DESCRIPTION
## Summary
- Issue #56 reported that `StreamRevisionConflictError.Error()` renders non-`Revision` `StreamState`s (`Any{}`, `NoStream{}`, `StreamExists{}`) as the useless literal `{}`, because `fmt`'s `%d` verb doesn't call `ToRawInt64()` on struct-typed interface values.
- That was already fixed incidentally in #66 (the doc-comment rewrite changed the format call from `s.ExpectedRevision, s.ActualRevision` to `s.ExpectedRevision.ToRawInt64(), s.ActualRevision.ToRawInt64()`), but there was no dedicated test covering non-`Revision` states.
- This PR adds that coverage to the existing `TestErrorStrings` table.

Fixes #56

## Test plan
- [x] Added a `StreamRevisionConflictError` case using `Any{}`/`StreamExists{}`, asserting the message contains their raw revisions (`-1`, `-2`) instead of `{}`
- [x] `go test -run TestErrorStrings -v .` — passes
- [x] `go build ./...` and `go vet ./...` — clean