### PR TITLE
Fix NewCommandHandler saving against the stale configured revision

### DIFF
--- a/command_handler.go
+++ b/command_handler.go
@@ -87,16 +87,27 @@ type CommandHandlerOption func(configuration *handlerOptions)
 // command to decide to get the events to persist; wraps them in
 // [Envelope]s, stamping each with a new UUID, the next sequential version,
 // the current time, and any metadata from functions added via
-// [WithMetadataExtractor]; and saves them with [EventStore.Save] against
-// the [StreamState] configured via [WithStreamState] (default [Any]).
+// [WithMetadataExtractor]; and saves them with [EventStore.Save].
+//
+// The [StreamState] configured via [WithStreamState] (default [Any])
+// determines how a save conflict is handled. [Any] and [StreamExists] don't
+// pin the stream to an exact version — [Any] asserts nothing, and
+// [StreamExists] only asserts non-emptiness, once loading has confirmed the
+// stream exists — so the handler saves against the revision it just loaded
+// and, on conflict, retries the whole load-evolve-decide-save cycle
+// according to the [backoff.BackOff] set via [WithRetryStrategy] (default:
+// no retries). [NoStream] and a specific [Revision] pin the stream to an
+// exact point (version 0, or N) that the caller explicitly asserted; a
+// conflict there means that expectation was violated, so it is returned
+// immediately rather than retried. A [StreamExists] load failure (the
+// stream doesn't exist yet) is likewise always returned immediately, never
+// retried — it's a fail-fast precondition, not a save conflict to converge
+// on. Any other Save or load error is also returned directly, without
+// retrying.
 //
 // If decide returns no events, the handler returns a successful
 // [AppendResult] without calling Save. If decide returns a non-nil error,
-// the handler returns it wrapped in an [ErrBusinessRuleViolation]. If Save
-// fails with a [StreamRevisionConflictError], the handler retries the whole
-// load-evolve-decide-save cycle according to the [backoff.BackOff] set via
-// [WithRetryStrategy] (default: no retries); any other Save or load error is
-// returned directly, without retrying.
+// the handler returns it wrapped in an [ErrBusinessRuleViolation].
 //
 // Example Usage:
 //
@@ -120,14 +131,28 @@ func NewCommandHandler[T any, C Command](
 		o(options)
 	}
 
+	// Revision and NoStream pin the stream to an exact point (a specific
+	// version, or version 0) that the caller explicitly asserted; retrying
+	// past that point would silently violate the expectation, so a
+	// conflict there is reported back immediately. That's also true of
+	// StreamExists failing to load: the stream doesn't exist (yet), which
+	// is a fail-fast condition, not a save conflict to converge on. But
+	// once a StreamExists load succeeds, the stream's existence is settled
+	// and only its version remains in question — from that point on it
+	// behaves like Any (no version pinned), tracking the version loaded
+	// and retrying on a save conflict.
+	_, isAny := options.Revision.(Any)
+	_, isStreamExists := options.Revision.(StreamExists)
+	autoConverge := isAny || isStreamExists
+
 	return func(ctx context.Context, command C) (AppendResult, error) {
 		// the stream ID for the given command
 		var streamID = options.StreamNamer(ctx, command)
 		// the state we will decide against
 		var state = initialState()
-		// the stream state we will save against
+		// the stream state we will load from, and (when autoConverge) save against
 		var revision = options.Revision
-		// the revision we
+		// the last version loaded from the stream
 		var lastVersion uint64
 		// Retry loop for handling concurrency conflicts
 		result, err := backoff.RetryWithData(func() (AppendResult, error) {
@@ -135,6 +160,11 @@ func NewCommandHandler[T any, C Command](
 			iter, err := store.LoadStreamFrom(ctx, streamID, revision)
 
 			if err != nil {
+				// Even for StreamExists, a missing stream fails fast here:
+				// the "auto-converge, don't pin a version" treatment only
+				// applies once the stream is confirmed to exist — this load
+				// error means it doesn't (yet), which is not something a
+				// save-conflict retry cycle can resolve.
 				return AppendResult{Successful: false, StreamID: streamID, NextExpectedVersion: lastVersion},
 					backoff.Permanent(fmt.Errorf("handle command %T for aggregate %q (streamID %q): load failed: %w", command, command.AggregateID(), streamID, err))
 			}
@@ -190,19 +220,31 @@ func NewCommandHandler[T any, C Command](
 			}
 
 			// --- Persist events ---
-			// TODO: this always saves against the originally configured
-			// options.Revision, not the Revision(lastVersion) derived from
-			// the stream just loaded above (see the `revision` var, which
-			// tracks it but is never used here). For a fixed Revision
-			// option this makes every retry re-check the same, now-stale,
-			// expectation instead of the current one.
-			result, err := store.Save(ctx, envelopes, options.Revision)
+			// With Any{} or StreamExists{}, save against the revision just
+			// loaded above (Revision(lastVersion)), so a conflict can be
+			// resolved by reloading and retrying. Revision(N) and NoStream{}
+			// pin the stream to an exact point the caller asserted, so they
+			// are saved against unchanged.
+			saveRevision := options.Revision
+			if autoConverge {
+				saveRevision = revision
+			}
+			result, err := store.Save(ctx, envelopes, saveRevision)
 
 			if err != nil {
 				var conflict *StreamRevisionConflictError
 				if errors.As(err, &conflict) {
-					// Retry on concurrency conflicts
-					return AppendResult{Successful: false, NextExpectedVersion: lastVersion + 1, StreamID: streamID}, conflict
+					if autoConverge {
+						// Retry: reload from `revision` and try again.
+						return AppendResult{Successful: false, NextExpectedVersion: lastVersion + 1, StreamID: streamID}, conflict
+					}
+					// The caller asserted a specific stream expectation
+					// (Revision or NoStream); a conflict means that
+					// expectation was violated, so it is reported back
+					// directly instead of being retried against a different
+					// target.
+					return AppendResult{Successful: false, NextExpectedVersion: lastVersion + 1, StreamID: streamID},
+						backoff.Permanent(fmt.Errorf("handle command %T for aggregate %q (streamID %q): concurrency conflict: %w", command, command.AggregateID(), streamID, conflict))
 				}
 				return result, backoff.Permanent(fmt.Errorf("handle command %T for aggregate %q (streamID %q): failed to save event: %w", command, command.AggregateID(), streamID, err))
 			}
@@ -235,9 +277,16 @@ type handlerOptions struct {
 }
 
 // WithStreamState sets the [StreamState] a [NewCommandHandler] expects the
-// stream to be in when it saves events — [Any] (the default) to skip the
-// check, [NoStream] or [StreamExists] to assert existence, or a specific
-// [Revision] to assert an exact version.
+// stream to be in when it saves events — [Any] (the default) to save
+// against the revision the handler just loaded, or [StreamExists] to do the
+// same after additionally requiring the stream to already exist; both retry
+// on save conflict per [WithRetryStrategy], since neither pins an exact
+// version. (A [StreamExists] load failure — the stream not existing yet —
+// is still a fail-fast precondition and is always returned immediately.)
+// [NoStream] (stream must not exist) or a specific [Revision] (stream must
+// be at exactly that version) pin the stream to an exact point the caller
+// explicitly asserted; a conflict there is always returned immediately,
+// never retried, since retrying would silently move past that point.
 //
 // Usage:
 //
@@ -247,9 +296,15 @@ func WithStreamState(rev StreamState) CommandHandlerOption {
 }
 
 // WithRetryStrategy sets the [backoff.BackOff] a [NewCommandHandler] uses to
-// retry its load-evolve-decide-save cycle after a
-// [StreamRevisionConflictError]. Without this option, no retries are
-// performed and the handler returns the conflict directly.
+// retry its load-evolve-decide-save cycle after a save conflict, when the
+// handler is configured (via [WithStreamState]) with [Any] (the default) or
+// [StreamExists] — neither pins the stream to an exact version, so a save
+// conflict can be resolved by retrying. It does not apply to a [StreamExists]
+// load failure (the stream not existing yet), which is always returned
+// immediately. Without this option, no retries are performed and the
+// handler returns the conflict directly. It has no effect when
+// [WithStreamState] is set to [NoStream] or a specific [Revision] — those
+// pin an exact point, so a conflict there is always returned immediately.
 //
 // Usage:
 //

--- a/command_handler_test.go
+++ b/command_handler_test.go
@@ -318,7 +318,7 @@ func TestNewCommandHandler_ExplicitRevision_Update(t *testing.T) {
 		func(s int, cmd testEvent) ([]Event, error) {
 			return []Event{testEvent{agg: cmd.AggregateID(), typ: "e"}}, nil
 		},
-		WithStreamState(Revision(5)), // will be updated to latest loaded revision (7)
+		WithStreamState(Revision(5)), // explicit Revision is a hard expectation and stays fixed
 	)
 
 	_, err := handler(context.Background(), testEvent{agg: "s", typ: "c"})
@@ -337,6 +337,194 @@ func TestNewCommandHandler_ExplicitRevision_Update(t *testing.T) {
 		}
 	default:
 		t.Fatalf("expected StreamState, got %T", seenRevision)
+	}
+}
+
+// TestNewCommandHandler_AnyRevision_RetryConverges is a regression test for
+// GitHub issue #23: with the default Any{} stream state, a save conflict
+// must be retried against the revision the handler just loaded, not a
+// stale one, so a competing writer landing between load and save doesn't
+// make every retry fail identically.
+func TestNewCommandHandler_AnyRevision_RetryConverges(t *testing.T) {
+	store := &testStore{}
+
+	// First load returns the stream as it was before a competing writer's
+	// append; the second load (triggered by the retry) returns the extra
+	// event that competing writer landed.
+	store.loadFn = func(ctx context.Context, stream string, from StreamState) (*Iterator[*Envelope], error) {
+		if store.loadCalled == 1 {
+			return newSliceEnvelopeIterator([]*Envelope{
+				{EventID: uuid.New(), StreamID: "s", Event: testEvent{agg: "s", typ: "old"}, Version: 1, OccurredAt: time.Now()},
+			}), nil
+		}
+		return newSliceEnvelopeIterator([]*Envelope{
+			{EventID: uuid.New(), StreamID: "s", Event: testEvent{agg: "s", typ: "foreign"}, Version: 2, OccurredAt: time.Now()},
+		}), nil
+	}
+
+	var seenRevisions []StreamState
+	store.saveFn = func(ctx context.Context, envelopes []Envelope, revision StreamState) (AppendResult, error) {
+		seenRevisions = append(seenRevisions, revision)
+		if len(seenRevisions) == 1 {
+			return AppendResult{}, &StreamRevisionConflictError{Stream: "s", ExpectedRevision: Revision(1), ActualRevision: Revision(2)}
+		}
+		return AppendResult{Successful: true, NextExpectedVersion: envelopes[len(envelopes)-1].Version}, nil
+	}
+
+	handler := NewCommandHandler(
+		store,
+		func() int { return 0 },
+		func(s int, e *Envelope) int { return s + 1 },
+		func(s int, cmd testEvent) ([]Event, error) {
+			return []Event{testEvent{agg: cmd.AggregateID(), typ: "e"}}, nil
+		},
+		WithRetryStrategy(backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond), 3)),
+	)
+
+	res, err := handler(context.Background(), testEvent{agg: "s", typ: "c"})
+	if err != nil {
+		t.Fatalf("expected retry to converge, got error: %v", err)
+	}
+	if !res.Successful {
+		t.Fatalf("expected successful append, got %+v", res)
+	}
+
+	if len(seenRevisions) != 2 {
+		t.Fatalf("expected 2 save attempts, got %d", len(seenRevisions))
+	}
+	if rv, ok := seenRevisions[0].(Revision); !ok || uint64(rv) != 1 {
+		t.Fatalf("expected first save to use Revision(1), got %#v", seenRevisions[0])
+	}
+	if rv, ok := seenRevisions[1].(Revision); !ok || uint64(rv) != 2 {
+		t.Fatalf("expected retried save to use Revision(2) (advanced past the foreign event), got %#v", seenRevisions[1])
+	}
+}
+
+// TestNewCommandHandler_ExplicitRevision_ConflictNotRetried verifies that a
+// caller-supplied Revision(N) is a hard expectation: a conflict against it
+// is returned immediately, even when a retry strategy is configured that
+// would otherwise allow retries.
+func TestNewCommandHandler_ExplicitRevision_ConflictNotRetried(t *testing.T) {
+	store := &testStore{}
+	store.loadFn = func(ctx context.Context, stream string, from StreamState) (*Iterator[*Envelope], error) {
+		return newSliceEnvelopeIterator(nil), nil
+	}
+	store.saveFn = func(ctx context.Context, envelopes []Envelope, revision StreamState) (AppendResult, error) {
+		return AppendResult{}, &StreamRevisionConflictError{Stream: "s", ExpectedRevision: Revision(0), ActualRevision: Revision(1)}
+	}
+
+	handler := NewCommandHandler(
+		store,
+		func() int { return 0 },
+		func(s int, e *Envelope) int { return s },
+		func(s int, cmd testEvent) ([]Event, error) {
+			return []Event{testEvent{agg: cmd.AggregateID(), typ: "e"}}, nil
+		},
+		WithStreamState(Revision(0)),
+		WithRetryStrategy(backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond), 5)),
+	)
+
+	_, err := handler(context.Background(), testEvent{agg: "s", typ: "c"})
+	if err == nil {
+		t.Fatalf("expected the explicit Revision(0) conflict to be returned as an error")
+	}
+	var conflict *StreamRevisionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected error to wrap *StreamRevisionConflictError, got: %v", err)
+	}
+	if store.saveCalled != 1 {
+		t.Fatalf("expected exactly 1 save attempt (no retry for an explicit Revision), got %d", store.saveCalled)
+	}
+}
+
+// TestNewCommandHandler_StreamExists_MissingStreamFailsFast verifies that a
+// StreamExists{} load failure (the stream doesn't exist yet) is returned
+// immediately, never retried — even with a retry strategy configured. Only
+// once a StreamExists load succeeds does the handler stop pinning an exact
+// expectation and start auto-converging on save conflicts (see
+// TestNewCommandHandler_StreamExists_ConflictRetries).
+func TestNewCommandHandler_StreamExists_MissingStreamFailsFast(t *testing.T) {
+	store := &testStore{}
+	store.loadFn = func(ctx context.Context, stream string, from StreamState) (*Iterator[*Envelope], error) {
+		return nil, fmt.Errorf("stream %q: should exist: %w", stream, ErrStreamNotFound)
+	}
+	store.saveFn = func(ctx context.Context, envelopes []Envelope, revision StreamState) (AppendResult, error) {
+		t.Fatalf("Save should not be called when the stream doesn't exist")
+		return AppendResult{}, nil
+	}
+
+	handler := NewCommandHandler(
+		store,
+		func() int { return 0 },
+		func(s int, e *Envelope) int { return s + 1 },
+		func(s int, cmd testEvent) ([]Event, error) {
+			return []Event{testEvent{agg: cmd.AggregateID(), typ: "e"}}, nil
+		},
+		WithStreamState(StreamExists{}),
+		WithRetryStrategy(backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond), 3)),
+	)
+
+	_, err := handler(context.Background(), testEvent{agg: "s", typ: "c"})
+	if err == nil {
+		t.Fatalf("expected an error when the stream doesn't exist")
+	}
+	if !errors.Is(err, ErrStreamNotFound) {
+		t.Fatalf("expected error to wrap ErrStreamNotFound, got: %v", err)
+	}
+	if store.loadCalled != 1 {
+		t.Fatalf("expected exactly 1 load attempt (no retry while the stream doesn't exist), got %d", store.loadCalled)
+	}
+}
+
+// TestNewCommandHandler_StreamExists_ConflictRetries verifies that once the
+// stream is confirmed to exist, StreamExists{} behaves like Any{} for
+// concurrency conflicts: it isn't pinned to a version, so a conflict is
+// resolved by reloading and retrying rather than failing immediately.
+func TestNewCommandHandler_StreamExists_ConflictRetries(t *testing.T) {
+	store := &testStore{}
+	store.loadFn = func(ctx context.Context, stream string, from StreamState) (*Iterator[*Envelope], error) {
+		if store.loadCalled == 1 {
+			return newSliceEnvelopeIterator([]*Envelope{
+				{EventID: uuid.New(), StreamID: "s", Event: testEvent{agg: "s", typ: "old"}, Version: 1, OccurredAt: time.Now()},
+			}), nil
+		}
+		return newSliceEnvelopeIterator([]*Envelope{
+			{EventID: uuid.New(), StreamID: "s", Event: testEvent{agg: "s", typ: "foreign"}, Version: 2, OccurredAt: time.Now()},
+		}), nil
+	}
+
+	var seenRevisions []StreamState
+	store.saveFn = func(ctx context.Context, envelopes []Envelope, revision StreamState) (AppendResult, error) {
+		seenRevisions = append(seenRevisions, revision)
+		if len(seenRevisions) == 1 {
+			return AppendResult{}, &StreamRevisionConflictError{Stream: "s", ExpectedRevision: Revision(1), ActualRevision: Revision(2)}
+		}
+		return AppendResult{Successful: true, NextExpectedVersion: envelopes[len(envelopes)-1].Version}, nil
+	}
+
+	handler := NewCommandHandler(
+		store,
+		func() int { return 0 },
+		func(s int, e *Envelope) int { return s + 1 },
+		func(s int, cmd testEvent) ([]Event, error) {
+			return []Event{testEvent{agg: cmd.AggregateID(), typ: "e"}}, nil
+		},
+		WithStreamState(StreamExists{}),
+		WithRetryStrategy(backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond), 3)),
+	)
+
+	res, err := handler(context.Background(), testEvent{agg: "s", typ: "c"})
+	if err != nil {
+		t.Fatalf("expected retry to converge, got error: %v", err)
+	}
+	if !res.Successful {
+		t.Fatalf("expected successful append, got %+v", res)
+	}
+	if len(seenRevisions) != 2 {
+		t.Fatalf("expected 2 save attempts, got %d", len(seenRevisions))
+	}
+	if rv, ok := seenRevisions[1].(Revision); !ok || uint64(rv) != 2 {
+		t.Fatalf("expected retried save to use Revision(2) (advanced past the foreign event), got %#v", seenRevisions[1])
 	}
 }
 

--- a/docs/explanation/concurrency.md
+++ b/docs/explanation/concurrency.md
@@ -29,7 +29,7 @@ Process B's save fails because the stream moved to v3 while it was deciding.
 
 ## How the library handles this
 
-`NewCommandHandler` tracks the last event version after loading. Before saving, it uses that version as the expected revision. If another write happened concurrently, `Save` returns `*StreamRevisionConflictError`.
+With the default `Any{}` stream state, `NewCommandHandler` tracks the last event version after loading and uses that version as the expected revision when saving — the caller hasn't pinned a specific version, so the handler is free to check against whatever it just loaded. If another write happened concurrently, `Save` returns `*StreamRevisionConflictError`.
 
 By default, the handler does **not** retry. To enable retries, pass `WithRetryStrategy`:
 
@@ -50,6 +50,10 @@ On conflict, the handler:
 3. Re-runs `decide` with the updated state.
 4. Retries `Save`.
 
+This retry-and-converge behavior applies to `Any{}` and, once the stream is confirmed to exist, `StreamExists{}` — neither pins the stream to an exact version, so a save conflict can be resolved by reloading and retrying. `NoStream{}` and a specific `Revision(N)` pin the stream to an exact point (version 0, or N) the caller explicitly asserted — a conflict there is returned immediately as `*StreamRevisionConflictError`, regardless of `WithRetryStrategy`. Retrying those wouldn't converge: silently re-checking against a stream a `NoStream{}` caller wanted empty, or resaving a `Revision(N)` caller pinned to a version they specifically read, would defeat the reason those checks were requested in the first place (e.g. detecting a lost update in an "edit this document at the version I last saw" flow).
+
+`StreamExists{}` also has a fail-fast side, distinct from a save conflict: if the stream doesn't exist *at all* when the handler loads it, that's a missing precondition, not a version race, and it's returned immediately — never retried — even with `WithRetryStrategy` configured. Only once loading succeeds (the stream is confirmed non-empty) does the "no version pinned, retry on conflict" behavior kick in for the subsequent save.
+
 ## CommandBus sharding
 
 The `CommandBus` provides an alternative approach: commands for the same aggregate are always routed to the same worker shard (via FNV hash of `AggregateID()`). Within a shard, commands are processed sequentially. This eliminates conflicts without requiring retries, at the cost of reduced throughput per shard.
@@ -60,12 +64,12 @@ Combine both approaches for maximum resilience: CommandBus reduces conflicts, an
 
 The `StreamState` type controls which concurrency check is applied:
 
-| State | Check |
-|---|---|
-| `Any{}` | No check (default) |
-| `NoStream{}` | Fail if stream exists |
-| `StreamExists{}` | Fail if stream does not exist |
-| `Revision(N)` | Fail if stream is not at version N (managed automatically by handler) |
+| State | Check | On conflict |
+|---|---|---|
+| `Any{}` | Checked against the version the handler just loaded (default) | retried per `WithRetryStrategy` |
+| `NoStream{}` | Fail if stream exists | returned immediately, never retried |
+| `StreamExists{}` | Fail if stream does not exist at load; once it does, checked against the loaded version like `Any{}` | load failure: returned immediately, never retried. Save conflict: retried per `WithRetryStrategy` |
+| `Revision(N)` | Fail if stream is not at version N | returned immediately, never retried |
 
 Use `NoStream{}` for creation commands to prevent duplicate aggregates:
 
@@ -80,6 +84,6 @@ See [Stream states reference](../reference/stream-states.md) for details.
 
 ## When conflicts cannot happen
 
-If only one process ever writes to an aggregate (guaranteed by the CommandBus or by design), or if the `decide` function is idempotent, you can use `Any{}` safely.
+`Any{}` always checks against the version the handler loaded, but if only one process ever writes to an aggregate (guaranteed by the CommandBus or by design), or if the `decide` function is idempotent, conflicts simply won't occur — so there's no need to configure `WithRetryStrategy` at all.
 
 For example, a processor that auto-archives tasks 30 days after completion might issue the same `ArchiveTask` command multiple times due to retries. Making `decide` return no events when the task is already archived eliminates the need for concurrency control entirely.

--- a/docs/reference/stream-states.md
+++ b/docs/reference/stream-states.md
@@ -16,11 +16,13 @@ type StreamState interface {
 type Any struct{}
 ```
 
-No concurrency check. Events are always appended regardless of the current stream version.
+No caller-specified expectation of the stream's version. This is the **default** for `NewCommandHandler`.
 
-**Use when**: Order of writes doesn't matter, or you handle conflicts in application logic.
+Passed directly to `EventStore.Save`, `Any{}` means no concurrency check — events are always appended regardless of the current stream version.
 
-This is the **default** for `NewCommandHandler`.
+`NewCommandHandler` behaves differently: it tracks the version it just loaded and saves against that instead, so a concurrent write is still detected as `*StreamRevisionConflictError` and, if `WithRetryStrategy` is configured, retried by reloading, re-deciding, and resaving until it converges. This is what "the framework manages Revision automatically" (below) refers to.
+
+**Use when**: You don't need to pin a specific version yourself and want the handler to resolve conflicts by retrying.
 
 ---
 
@@ -52,6 +54,8 @@ The stream **must exist**. If it doesn't, `Save` returns `ErrStreamNotFound` and
 
 **Use when**: A command targets an existing aggregate and you want to fail fast if it was never created.
 
+In `NewCommandHandler`, that "fail fast" only covers the missing-stream case: a load failure because the stream doesn't exist yet is always returned immediately, never retried, even with `WithRetryStrategy` configured — it's a precondition, not a version race. But once the stream is confirmed to exist, `StreamExists` isn't pinned to a specific version any more than `Any` is, so a subsequent save conflict is retried the same way `Any` converges (see [Any](#any) above).
+
 ---
 
 ## Revision
@@ -62,10 +66,13 @@ type Revision uint64
 
 The stream must be at exactly this version. If the actual version differs, `Save` returns `*StreamRevisionConflictError`.
 
-**Use when**: Implementing optimistic concurrency. `NewCommandHandler` manages this automatically during retries — you should not normally set `Revision` manually.
+**Use when**: You've read the stream at a specific version yourself (e.g. an API caller round-tripping a version from an earlier read) and want to detect — not silently absorb — a change since then. A conflict is always returned immediately, never retried: retrying would move past the exact version you pinned, defeating the reason you asserted it.
+
+You should not normally set `Revision` manually just to get optimistic concurrency inside `NewCommandHandler` — use the default `Any{}` for that, which tracks the loaded version and retries on conflict automatically:
 
 ```go
-// The framework sets this internally after loading events:
+// With Any{}, the framework tracks this internally after loading events
+// and saves against it, instead of a caller-supplied Revision:
 revision = eventsourcing.Revision(lastLoadedVersion)
 ```
 


### PR DESCRIPTION
## Summary
- `NewCommandHandler` always called `Save` with `options.Revision` (captured at construction time) instead of the locally tracked revision, so `WithStreamState(Revision(N))` made every retry re-check the same, now-stale expectation and could never converge after a `StreamRevisionConflictError`.
- The fix doesn't make `Revision(N)` auto-converge, since that would silently move a caller's explicitly-pinned expectation past the version they asserted (defeating lost-update / If-Match style checks). Instead, `NewCommandHandler` now only auto-tracks-and-retries for stream states that don't pin an exact version:
  - `Any{}` (default): saves against `Revision(lastVersion)`, retries on conflict per `WithRetryStrategy`.
  - `StreamExists{}`: fails fast if the stream doesn't exist yet (a precondition, not a race); once confirmed to exist, behaves like `Any{}` and retries on save conflict.
  - `NoStream{}` and a specific `Revision(N)`: pinned to an exact point (version 0, or N); a conflict is always returned immediately, never retried.
- Updated `docs/explanation/concurrency.md` and `docs/reference/stream-states.md` to describe this accurately (they previously contradicted both each other and the actual code).

Fixes #23. Note: #23's own repro test expected `Revision(0)` to auto-converge — under this fix that scenario now fails fast by design instead; see the issue comment for the full explanation of why, and the equivalent converging tests added here for `Any{}`/`StreamExists{}`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all command-handler tests pass (13, up from 9); 4 pre-existing unrelated failures elsewhere (untracked regression tests for separate known bugs in filestore/postgres/eventbus) are unchanged by this PR
- [x] New tests: `TestNewCommandHandler_AnyRevision_RetryConverges`, `TestNewCommandHandler_ExplicitRevision_ConflictNotRetried`, `TestNewCommandHandler_StreamExists_MissingStreamFailsFast`, `TestNewCommandHandler_StreamExists_ConflictRetries`