### PR TITLE
Give each envelope in a batch its own Metadata map

### DIFF
--- a/command_handler.go
+++ b/command_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -201,9 +202,7 @@ func NewCommandHandler[T any, C Command](
 			envelopes := make([]Envelope, len(events))
 			baseMetadata := make(map[string]any)
 			for _, fn := range options.MetadataFuncs {
-				for k, v := range fn(ctx) {
-					baseMetadata[k] = v
-				}
+				maps.Copy(baseMetadata, fn(ctx))
 			}
 
 			nextVersion := lastVersion + 1
@@ -213,7 +212,7 @@ func NewCommandHandler[T any, C Command](
 					EventID:    uuid.New(),
 					StreamID:   streamID,
 					Event:      event,
-					Metadata:   baseMetadata,
+					Metadata:   maps.Clone(baseMetadata),
 					Version:    nextVersion + uint64(i),
 					OccurredAt: time.Now(),
 				}

--- a/command_handler_test.go
+++ b/command_handler_test.go
@@ -598,6 +598,60 @@ func TestNewCommandHandler_MetadataMergeOrder(t *testing.T) {
 	}
 }
 
+// TestNewCommandHandler_EnvelopesDoNotShareMetadataMap is a regression test
+// for GitHub issue #24: when decide produces multiple events, every envelope
+// in the batch used to get the same *map[string]any* instance for Metadata,
+// so mutating one envelope's metadata after the fact (e.g. a per-event
+// causation_id, as otel.TelemetryStore.Save adds) silently mutated every
+// other envelope's metadata too.
+func TestNewCommandHandler_EnvelopesDoNotShareMetadataMap(t *testing.T) {
+	var savedEnvelopes []Envelope
+	store := &testStore{
+		loadFn: func(ctx context.Context, stream string, from StreamState) (*Iterator[*Envelope], error) {
+			return newSliceEnvelopeIterator(nil), nil
+		},
+		saveFn: func(ctx context.Context, envelopes []Envelope, revision StreamState) (AppendResult, error) {
+			savedEnvelopes = envelopes
+			return AppendResult{Successful: true, StreamID: "s"}, nil
+		},
+	}
+
+	handler := NewCommandHandler(
+		store,
+		func() int { return 0 },
+		func(state int, env *Envelope) int { return state + 1 },
+		func(state int, cmd testEvent) ([]Event, error) {
+			return []Event{
+				testEvent{agg: cmd.AggregateID(), typ: "first"},
+				testEvent{agg: cmd.AggregateID(), typ: "second"},
+			}, nil
+		},
+		WithMetadataExtractor(func(ctx context.Context) map[string]any {
+			return map[string]any{"seed": "value"}
+		}),
+	)
+
+	res, err := handler(context.Background(), testEvent{agg: "s", typ: "c"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Successful {
+		t.Fatalf("expected successful append, got %+v", res)
+	}
+	if len(savedEnvelopes) != 2 {
+		t.Fatalf("expected 2 saved envelopes, got %d", len(savedEnvelopes))
+	}
+
+	// Simulate a consumer enriching only the FIRST event's metadata after the
+	// batch was produced (e.g. the otel decorator's per-event causation_id).
+	savedEnvelopes[0].Metadata["causation_id"] = "abc-123"
+
+	if v, ok := savedEnvelopes[1].Metadata["causation_id"]; ok {
+		t.Fatalf("second event's metadata was mutated by writing to the first "+
+			"event's metadata map: got causation_id=%v", v)
+	}
+}
+
 func TestNewCommandHandler_UnregisteredEventError(t *testing.T) {
 	// This test verifies that when an iterator encounters an unregistered event
 	// (e.g., from NewEventByName failing), the error is properly propagated


### PR DESCRIPTION
## Summary
- `NewCommandHandler` built one `baseMetadata` map per command invocation and assigned that same map instance to every `Envelope` in the batch when `decide` produced more than one event. Mutating one envelope's `Metadata` after the fact (e.g. `otel.TelemetryStore.Save` adding a per-event `causation_id`) silently mutated every other envelope's `Metadata` too, since they were literally the same Go map value — contradicting the handler's own godoc, which promises each envelope gets its own metadata map.
- Fixed by using `maps.Clone` to give each envelope an independent copy, and simplified the merge loop that builds `baseMetadata` from the configured `MetadataFuncs` with `maps.Copy`.

Fixes #24

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all pass (155)
- [x] Added `TestNewCommandHandler_EnvelopesDoNotShareMetadataMap` (adapted from the issue's repro), confirms mutating one envelope's metadata no longer affects sibling envelopes in the same batch
- [x] `NewCommandHandler` remains at 100% branch coverage