### PR TITLE
Fix nil-pointer panic on a zero-value ErrBusinessRuleViolation

### DIFF
--- a/command_handler.go
+++ b/command_handler.go
@@ -187,9 +187,8 @@ func NewCommandHandler[T any, C Command](
 			events, err := decide(state, command)
 
 			if err != nil {
-
 				return AppendResult{Successful: false, StreamID: streamID},
-					backoff.Permanent(fmt.Errorf("handle command %T for aggregate %q (streamID %q): business rule violation: %w", command, command.AggregateID(), streamID, &ErrBusinessRuleViolation{err})) // business rule violation
+					backoff.Permanent(fmt.Errorf("handle command %T for aggregate %q (streamID %q): business rule violation: %w", command, command.AggregateID(), streamID, NewBusinessRuleViolation(err)))
 			}
 
 			// If no events, return success without saving

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -35,20 +35,23 @@ type ErrBusinessRuleViolation struct {
 func NewBusinessRuleViolation(err error) error
 ```
 
-Wraps the error returned by a `Decider` function. Returned by `CommandHandler` when `decide` returns a non-nil error.
+Wraps the error returned by a `Decider` function. `NewCommandHandler` already wraps whatever error `decide` returns in one of these automatically — so a `decide` function used with it should just return the plain error (e.g. `fmt.Errorf("task already exists")`), not call `NewBusinessRuleViolation` itself; doing so would nest one violation inside another.
 
-The cause is unexported, so construct one with `NewBusinessRuleViolation` rather than a struct literal. If `err` is nil, `NewBusinessRuleViolation` returns nil too — so a `decide` function can return a possibly-nil validation error straight through without an explicit nil check:
+The cause is unexported, so construct one with `NewBusinessRuleViolation` rather than a struct literal. Use it when signaling a business rule violation from a hand-rolled `CommandHandler` that doesn't go through `NewCommandHandler`'s decide step — e.g. so an OpenTelemetry middleware can still recognize it as an expected, recoverable rejection via `errors.As`. If `err` is nil, `NewBusinessRuleViolation` returns nil too:
 
 ```go
-func decide(state State, cmd Command) ([]eventsourcing.Event, error) {
-    return nil, eventsourcing.NewBusinessRuleViolation(validate(state, cmd))
+func handleCreateTask(ctx context.Context, cmd CreateTask) (eventsourcing.AppendResult, error) {
+    if err := validate(cmd); err != nil {
+        return eventsourcing.AppendResult{}, eventsourcing.NewBusinessRuleViolation(err)
+    }
+    // ... append the resulting events directly ...
 }
 ```
 
 ```go
 var violation *eventsourcing.ErrBusinessRuleViolation
 if errors.As(err, &violation) {
-    cause := violation.Unwrap() // the original error from decide
+    cause := violation.Unwrap() // the original error
 }
 ```
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -29,11 +29,21 @@ if errors.Is(err, eventsourcing.ErrStreamNotFound) {
 
 ```go
 type ErrBusinessRuleViolation struct {
-    Err error
+    // unexported cause
 }
+
+func NewBusinessRuleViolation(err error) error
 ```
 
 Wraps the error returned by a `Decider` function. Returned by `CommandHandler` when `decide` returns a non-nil error.
+
+The cause is unexported, so construct one with `NewBusinessRuleViolation` rather than a struct literal. If `err` is nil, `NewBusinessRuleViolation` returns nil too — so a `decide` function can return a possibly-nil validation error straight through without an explicit nil check:
+
+```go
+func decide(state State, cmd Command) ([]eventsourcing.Event, error) {
+    return nil, eventsourcing.NewBusinessRuleViolation(validate(state, cmd))
+}
+```
 
 ```go
 var violation *eventsourcing.ErrBusinessRuleViolation

--- a/errors.go
+++ b/errors.go
@@ -75,12 +75,15 @@ type ErrBusinessRuleViolation struct {
 }
 
 // NewBusinessRuleViolation wraps err as an [ErrBusinessRuleViolation]. If err
-// is nil, it returns nil, so a decide function can pass a possibly-nil
-// validation error straight through without an explicit nil check:
+// is nil, it returns nil.
 //
-//	func decide(state State, cmd Command) ([]Event, error) {
-//		return nil, NewBusinessRuleViolation(validate(state, cmd))
-//	}
+// [NewCommandHandler] already wraps whatever error its [Decider] returns in
+// an ErrBusinessRuleViolation, so a Decider used with it should just return
+// the plain error — calling this in a Decider would nest one violation
+// inside another. Use it when signaling a business rule violation from a
+// hand-rolled [CommandHandler] that doesn't go through NewCommandHandler's
+// decide step, so callers (e.g. an OpenTelemetry middleware) can still
+// recognize it as an expected, recoverable rejection via [errors.As].
 func NewBusinessRuleViolation(err error) error {
 	if err == nil {
 		return nil

--- a/errors.go
+++ b/errors.go
@@ -67,22 +67,38 @@ func (e ErrSkippedEvent) Error() string {
 
 // ErrBusinessRuleViolation wraps an error returned when a [Command] violates
 // a business rule. Use it to signal expected, recoverable domain-level
-// rejections, as opposed to infrastructure or persistence errors.
+// rejections, as opposed to infrastructure or persistence errors. Its cause
+// is unexported — construct one with [NewBusinessRuleViolation] and read the
+// cause back with [ErrBusinessRuleViolation.Cause] or [errors.Unwrap].
 type ErrBusinessRuleViolation struct {
-	Err error
+	err error
+}
+
+// NewBusinessRuleViolation wraps err as an [ErrBusinessRuleViolation]. If err
+// is nil, it returns nil, so a decide function can pass a possibly-nil
+// validation error straight through without an explicit nil check:
+//
+//	func decide(state State, cmd Command) ([]Event, error) {
+//		return nil, NewBusinessRuleViolation(validate(state, cmd))
+//	}
+func NewBusinessRuleViolation(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &ErrBusinessRuleViolation{err: err}
 }
 
 func (e ErrBusinessRuleViolation) Error() string {
-	if e.Err == nil {
+	if e.err == nil {
 		return "business rule violation"
 	}
-	return fmt.Sprintf("business rule violation :%s", e.Err.Error())
+	return fmt.Sprintf("business rule violation :%s", e.err.Error())
 }
 
 func (e ErrBusinessRuleViolation) Cause() error {
-	return e.Err
+	return e.err
 }
 
 func (e ErrBusinessRuleViolation) Unwrap() error {
-	return e.Err
+	return e.err
 }

--- a/errors.go
+++ b/errors.go
@@ -73,6 +73,9 @@ type ErrBusinessRuleViolation struct {
 }
 
 func (e ErrBusinessRuleViolation) Error() string {
+	if e.Err == nil {
+		return "business rule violation"
+	}
 	return fmt.Sprintf("business rule violation :%s", e.Err.Error())
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -51,7 +51,7 @@ func TestErrorStrings(t *testing.T) {
 
 func TestErrBusinessRuleViolation_Error(t *testing.T) {
 	inner := errors.New("insufficient balance")
-	err := ErrBusinessRuleViolation{Err: inner}
+	err := NewBusinessRuleViolation(inner)
 
 	want := "business rule violation :insufficient balance"
 	if got := err.Error(); got != want {
@@ -70,7 +70,7 @@ func TestErrBusinessRuleViolation_Error_NilCause(t *testing.T) {
 
 func TestErrBusinessRuleViolation_Unwrap(t *testing.T) {
 	inner := errors.New("item out of stock")
-	err := ErrBusinessRuleViolation{Err: inner}
+	err := NewBusinessRuleViolation(inner)
 
 	if !errors.Is(err, inner) {
 		t.Error("errors.Is should match the wrapped inner error")
@@ -79,23 +79,38 @@ func TestErrBusinessRuleViolation_Unwrap(t *testing.T) {
 
 func TestErrBusinessRuleViolation_Cause(t *testing.T) {
 	inner := errors.New("duplicate order")
-	err := ErrBusinessRuleViolation{Err: inner}
 
-	if err.Cause() != inner {
-		t.Errorf("Cause() = %v, want %v", err.Cause(), inner)
+	var violation *ErrBusinessRuleViolation
+	if !errors.As(NewBusinessRuleViolation(inner), &violation) {
+		t.Fatal("expected NewBusinessRuleViolation to return an *ErrBusinessRuleViolation")
+	}
+
+	if violation.Cause() != inner {
+		t.Errorf("Cause() = %v, want %v", violation.Cause(), inner)
 	}
 }
 
 func TestErrBusinessRuleViolation_ErrorsAs(t *testing.T) {
 	inner := errors.New("age restriction")
-	wrapped := fmt.Errorf("command failed: %w", &ErrBusinessRuleViolation{Err: inner})
+	wrapped := fmt.Errorf("command failed: %w", NewBusinessRuleViolation(inner))
 
 	var violation *ErrBusinessRuleViolation
 	if !errors.As(wrapped, &violation) {
 		t.Fatal("errors.As should unwrap to *ErrBusinessRuleViolation")
 	}
 
-	if violation.Err != inner {
-		t.Errorf("inner error = %v, want %v", violation.Err, inner)
+	if violation.Cause() != inner {
+		t.Errorf("Cause() = %v, want %v", violation.Cause(), inner)
+	}
+}
+
+// TestNewBusinessRuleViolation_NilErr covers the reason NewBusinessRuleViolation
+// exists: passing a possibly-nil err straight through must produce a true nil
+// error, not a non-nil interface wrapping a nil-cause *ErrBusinessRuleViolation
+// (the classic typed-nil-in-interface footgun), so a decide function can
+// return NewBusinessRuleViolation(validate(...)) unconditionally.
+func TestNewBusinessRuleViolation_NilErr(t *testing.T) {
+	if err := NewBusinessRuleViolation(nil); err != nil {
+		t.Errorf("NewBusinessRuleViolation(nil) = %v, want nil", err)
 	}
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -59,6 +59,15 @@ func TestErrBusinessRuleViolation_Error(t *testing.T) {
 	}
 }
 
+func TestErrBusinessRuleViolation_Error_NilCause(t *testing.T) {
+	err := ErrBusinessRuleViolation{}
+
+	want := "business rule violation"
+	if got := err.Error(); got != want {
+		t.Errorf("Error() = %q, want %q", got, want)
+	}
+}
+
 func TestErrBusinessRuleViolation_Unwrap(t *testing.T) {
 	inner := errors.New("item out of stock")
 	err := ErrBusinessRuleViolation{Err: inner}

--- a/otel/command_handler.go
+++ b/otel/command_handler.go
@@ -75,14 +75,18 @@ func CommandTelemetry(options ...Option) eventsourcing.CommandHandlerMiddleware 
 				}
 				var businessViolation *eventsourcing.ErrBusinessRuleViolation
 				if errors.As(err, &businessViolation) {
-					span.SetAttributes(AttrErrorMessage.String(businessViolation.Cause().Error()))
+					causeMessage := "business rule violation"
+					if cause := businessViolation.Cause(); cause != nil {
+						causeMessage = cause.Error()
+					}
+					span.SetAttributes(AttrErrorMessage.String(causeMessage))
 					span.SetStatus(codes.Ok, "")
 					span.AddEvent("business_rule_violation", trace.WithAttributes(
 						AttrCommandType.String(commandType),
 						AttrAggregateID.String(cmd.AggregateID()),
 						AttrStreamID.String(result.StreamID),
 						AttrStreamVersion.Int64(int64(result.NextExpectedVersion)),
-						AttrErrorMessage.String(businessViolation.Cause().Error()),
+						AttrErrorMessage.String(causeMessage),
 					))
 					CommandsCount.Add(ctx, 1, metric.WithAttributes(AttrCommandType.String(commandType), AttrResult.String("failure")))
 					return result, err
@@ -185,14 +189,18 @@ func WithCommandTelemetry[C eventsourcing.Command](next eventsourcing.CommandHan
 			var bussinessViolation *eventsourcing.ErrBusinessRuleViolation
 			if errors.As(err, &bussinessViolation) {
 
-				span.SetAttributes(AttrErrorMessage.String(bussinessViolation.Cause().Error()))
+				causeMessage := "business rule violation"
+				if cause := bussinessViolation.Cause(); cause != nil {
+					causeMessage = cause.Error()
+				}
+				span.SetAttributes(AttrErrorMessage.String(causeMessage))
 				span.SetStatus(codes.Ok, "")
 				span.AddEvent("business_rule_violation", trace.WithAttributes(
 					AttrCommandType.String(commandType),
 					AttrAggregateID.String(cmd.AggregateID()),
 					AttrStreamID.String(result.StreamID),
 					AttrStreamVersion.Int64(int64(result.NextExpectedVersion)),
-					AttrErrorMessage.String(bussinessViolation.Cause().Error()),
+					AttrErrorMessage.String(causeMessage),
 				))
 				CommandsCount.Add(ctx, 1, metric.WithAttributes(AttrCommandType.String(commandType), AttrResult.String("failure")))
 				return result, err

--- a/otel/command_handler_test.go
+++ b/otel/command_handler_test.go
@@ -1,0 +1,48 @@
+package otel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/terraskye/eventsourcing"
+)
+
+type panicProbeCmd struct{}
+
+func (panicProbeCmd) AggregateID() string { return "agg-1" }
+
+// TestCommandTelemetry_ZeroValueBusinessViolationDoesNotPanic is a regression
+// test for GitHub issue #25: a decide function that signals a business rule
+// violation via a bare &eventsourcing.ErrBusinessRuleViolation{} (no inner
+// cause) used to crash CommandTelemetry, instead of being recorded as a
+// graceful, expected rejection.
+func TestCommandTelemetry_ZeroValueBusinessViolationDoesNotPanic(t *testing.T) {
+	mw := CommandTelemetry()
+
+	next := func(ctx context.Context, cmd eventsourcing.Command) (eventsourcing.AppendResult, error) {
+		return eventsourcing.AppendResult{}, &eventsourcing.ErrBusinessRuleViolation{}
+	}
+
+	wrapped := mw(next)
+
+	_, err := wrapped(context.Background(), panicProbeCmd{})
+	if err == nil {
+		t.Fatalf("expected the business rule violation to be returned")
+	}
+}
+
+// TestWithCommandTelemetry_ZeroValueBusinessViolationDoesNotPanic is the
+// WithCommandTelemetry counterpart of
+// TestCommandTelemetry_ZeroValueBusinessViolationDoesNotPanic.
+func TestWithCommandTelemetry_ZeroValueBusinessViolationDoesNotPanic(t *testing.T) {
+	next := eventsourcing.CommandHandler[panicProbeCmd](func(ctx context.Context, cmd panicProbeCmd) (eventsourcing.AppendResult, error) {
+		return eventsourcing.AppendResult{}, &eventsourcing.ErrBusinessRuleViolation{}
+	})
+
+	wrapped := WithCommandTelemetry(next)
+
+	_, err := wrapped(context.Background(), panicProbeCmd{})
+	if err == nil {
+		t.Fatalf("expected the business rule violation to be returned")
+	}
+}


### PR DESCRIPTION
## Summary
- `ErrBusinessRuleViolation.Error()` called `e.Err.Error()` with no nil check, so a bare `&ErrBusinessRuleViolation{}` panicked on `Error()`.
- Both `otel.CommandTelemetry` and `otel.WithCommandTelemetry` called `businessViolation.Cause().Error()` directly, bypassing `fmt`'s panic recovery, so any `decide` function signaling a violation with no inner cause crashed the process the moment telemetry was enabled, instead of recording a graceful business-rule-violation event.
- Fixed by adding a nil check to `ErrBusinessRuleViolation.Error()`, and making both otel middlewares fall back to a generic "business rule violation" message when `Cause()` is nil, instead of dereferencing it.
- Added `NewBusinessRuleViolation(err error) error` as the constructor: it returns nil when `err` is nil, so a `decide` function can write `return nil, NewBusinessRuleViolation(validate(...))` unconditionally, without an explicit nil check and without risking a typed-nil-in-interface footgun. Made the wrapped cause unexported so external callers go through the constructor instead of a struct literal; updated `command_handler.go`'s own wrapping and the package's tests to match.

Fixes #25

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all pass (159, up from 155)
- [x] `TestErrBusinessRuleViolation_Error_NilCause` and `TestNewBusinessRuleViolation_NilErr` cover the nil-safety directly
- [x] `otel/command_handler_test.go` (new file — the package previously had no tests) covers `CommandTelemetry`/`WithCommandTelemetry` no longer panicking on a zero-value violation