### PR TITLE
Fix Subscribe leaking a ctx-watcher goroutine per call

### DIFF
--- a/eventbus/file/eventbus.go
+++ b/eventbus/file/eventbus.go
@@ -100,7 +100,9 @@ func (b *FileEventBus) Use(middlewares ...eventsourcing.EventHandlerMiddleware) 
 // event; pass [WithFilterEvents] to restrict delivery to specific event
 // types. It returns an error if handler is nil, the bus is already closed,
 // name is already registered, or the subscriber directory cannot be
-// created. The subscription is removed automatically when ctx is canceled.
+// created. The subscription is removed automatically when ctx is canceled,
+// or when the bus is closed — neither leaves a goroutine behind, even if
+// ctx is long-lived (e.g. context.Background()).
 func (b *FileEventBus) Subscribe(
 	ctx context.Context,
 	name string,
@@ -151,8 +153,16 @@ func (b *FileEventBus) Subscribe(
 	b.wg.Add(1)
 	go b.runSubscriber(workerCtx, s, subDir)
 
+	// workerCtx is a child of ctx, so its Done channel closes whenever
+	// either the caller cancels ctx (auto-unsubscribe) or Close/
+	// removeSubscriber calls cancel directly — one signal to watch for
+	// both triggers, rather than parking on the caller's ctx alone, which
+	// never fires (and leaks this goroutine) for a long-lived ctx such as
+	// context.Background().
+	b.wg.Add(1)
 	go func() {
-		<-ctx.Done()
+		defer b.wg.Done()
+		<-workerCtx.Done()
 		b.removeSubscriber(name)
 	}()
 

--- a/eventbus/file/eventbus_test.go
+++ b/eventbus/file/eventbus_test.go
@@ -2,8 +2,11 @@ package file
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -102,5 +105,63 @@ func TestFileEventBusClose_LetsInFlightHandlerFinish(t *testing.T) {
 	case <-closeDone:
 	case <-time.After(2 * time.Second):
 		t.Fatal("Close never returned")
+	}
+}
+
+// countGoroutinesCreatedBy reports the number of goroutines in a full stack
+// dump whose "created by" line contains substr.
+func countGoroutinesCreatedBy(substr string) int {
+	buf := make([]byte, 4<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), substr)
+}
+
+// TestSubscribe_CtxWatcherGoroutineLeaksAfterClose is a regression test for
+// GitHub issue #27: Subscribe's ctx-watcher goroutine used to block on
+// <-ctx.Done() alone, which never fires for a long-lived ctx such as
+// context.Background() (used by every other test in this file, and by every
+// example in the repo) — leaking one goroutine per Subscribe call for the
+// rest of the process's life, unaffected by Close.
+func TestSubscribe_CtxWatcherGoroutineLeaksAfterClose(t *testing.T) {
+	const n = 20
+	const createdBy = "created by github.com/terraskye/eventsourcing/eventbus/file.(*FileEventBus).Subscribe"
+
+	root := t.TempDir()
+	bus, err := NewFileEventBus(root)
+	if err != nil {
+		t.Fatalf("NewFileEventBus: %v", err)
+	}
+
+	before := countGoroutinesCreatedBy(createdBy)
+
+	noop := eventsourcing.NewEventHandlerFunc(func(ctx context.Context, ev eventsourcing.Event) error {
+		return nil
+	})
+
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("sub-%d", i)
+		if err := bus.Subscribe(context.Background(), name, noop); err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+	}
+
+	// Let the fsnotify watchers come up before closing.
+	time.Sleep(200 * time.Millisecond)
+
+	if err := bus.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Give any well-behaved goroutines a chance to exit.
+	time.Sleep(300 * time.Millisecond)
+	runtime.GC()
+
+	after := countGoroutinesCreatedBy(createdBy)
+
+	// Correct behaviour: once Close() has fully torn down the bus, no
+	// ctx-watcher goroutines from Subscribe should remain running.
+	leaked := after - before
+	if leaked > 0 {
+		t.Fatalf("expected 0 leaked ctx-watcher goroutines after Close, got %d (before=%d after=%d)", leaked, before, after)
 	}
 }


### PR DESCRIPTION
## Summary
- The goroutine that auto-removes a subscriber blocked on `<-ctx.Done()` alone, which never fires for a long-lived `ctx` such as `context.Background()` (used by every other test in this package, and by every example in the repo) — leaking one goroutine per `Subscribe` call for the rest of the process's life, unaffected by `Close`.
- `workerCtx` is already a child of `ctx` (`context.WithCancel(ctx)`, from the #26 fix), so its `Done` channel closes whenever either the caller cancels `ctx` or `Close`/`removeSubscriber` cancels it directly. Watching `workerCtx.Done()` instead covers both triggers with one signal.
- Tracked the goroutine with `b.wg` so `Close`'s `wg.Wait()` actually waits for it, guaranteeing no leak remains once `Close` returns.

Fixes #27

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (162, up from 161)
- [x] Added `TestSubscribe_CtxWatcherGoroutineLeaksAfterClose` (adapted from the issue's repro). Verified it actually catches the bug: reverted the fix, confirmed the test failed with the exact reported result (20 leaked goroutines), then restored the fix and confirmed it passes