### PR TITLE
Fix Use racing with Subscribe on b.middlewares

### DIFF
--- a/eventbus/file/eventbus.go
+++ b/eventbus/file/eventbus.go
@@ -89,8 +89,11 @@ func NewFileEventBus(root string) (*FileEventBus, error) {
 // Use adds middlewares that wrap every handler registered afterward via
 // Subscribe. As required by [eventsourcing.EventBus], it must be called
 // before Subscribe: middlewares added after a given subscriber is
-// registered do not apply to that subscriber.
+// registered do not apply to that subscriber. Use and Subscribe are both
+// safe to call concurrently.
 func (b *FileEventBus) Use(middlewares ...eventsourcing.EventHandlerMiddleware) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.middlewares = append(b.middlewares, middlewares...)
 }
 
@@ -118,11 +121,6 @@ func (b *FileEventBus) Subscribe(
 		opt(cfg)
 	}
 
-	wrapped := handler
-	for i := len(b.middlewares) - 1; i >= 0; i-- {
-		wrapped = b.middlewares[i](wrapped)
-	}
-
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -132,6 +130,11 @@ func (b *FileEventBus) Subscribe(
 
 	if _, exists := b.subs[name]; exists {
 		return fmt.Errorf("subscriber %q already exists", name)
+	}
+
+	wrapped := handler
+	for i := len(b.middlewares) - 1; i >= 0; i-- {
+		wrapped = b.middlewares[i](wrapped)
 	}
 
 	subDir := filepath.Join(b.root, name)

--- a/eventbus/file/eventbus_test.go
+++ b/eventbus/file/eventbus_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -164,4 +165,39 @@ func TestSubscribe_CtxWatcherGoroutineLeaksAfterClose(t *testing.T) {
 	if leaked > 0 {
 		t.Fatalf("expected 0 leaked ctx-watcher goroutines after Close, got %d (before=%d after=%d)", leaked, before, after)
 	}
+}
+
+// TestFileEventBus_UseRacesWithSubscribe is a regression test for GitHub
+// issue #28: Use appended to b.middlewares with no synchronization, and
+// Subscribe read b.middlewares before acquiring b.mu, so calling Use
+// concurrently with Subscribe was a data race under `go test -race`.
+func TestFileEventBus_UseRacesWithSubscribe(t *testing.T) {
+	root := t.TempDir()
+	bus, err := NewFileEventBus(root)
+	if err != nil {
+		t.Fatalf("NewFileEventBus: %v", err)
+	}
+	defer bus.Close()
+
+	noopMiddleware := func(next eventsourcing.EventHandler) eventsourcing.EventHandler {
+		return next
+	}
+	handler := eventsourcing.NewEventHandlerFunc(func(ctx context.Context, event eventsourcing.Event) error {
+		return nil
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		bus.Use(noopMiddleware)
+	}()
+
+	go func() {
+		defer wg.Done()
+		_ = bus.Subscribe(context.Background(), "sub-1", handler)
+	}()
+
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
- `Use` appended to `b.middlewares` with no synchronization at all, and `Subscribe` read `b.middlewares` before acquiring `b.mu`, so calling `Use` concurrently with `Subscribe` was a data race under `go test -race` — undefined behavior (can panic or read garbage), not just a stale middleware list.
- Guarded the append in `Use` with `b.mu`, and moved `Subscribe`'s middleware-wrapping loop to after it acquires `b.mu`, reusing the same lock that already guards `subs` and `closed` instead of adding a separate one.

Fixes #28

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (163, up from 162)
- [x] Added `TestFileEventBus_UseRacesWithSubscribe` (adapted from the issue's repro). Verified it actually catches the bug: reverted the fix and reproduced both races the issue describes (the field race and the `runtime.slicecopy` race, 2/10 runs), then restored the fix and confirmed 20/20 clean under `-race`