### PR TITLE
Fix WithEnvelope panicking on a nil Envelope.Event

### DIFF
--- a/context.go
+++ b/context.go
@@ -23,10 +23,16 @@ const (
 // WithEnvelope returns a copy of ctx carrying env's stream ID, aggregate ID,
 // event ID, version, global version, occurred-at time, and metadata,
 // retrievable via the *FromContext functions below. It does not carry a
-// causation ID; use [WithCausation] for that.
+// causation ID; use [WithCausation] for that. The aggregate ID is "" if
+// env.Event is nil.
 func WithEnvelope(ctx context.Context, env *Envelope) context.Context {
+	var aggregateID string
+	if env.Event != nil {
+		aggregateID = env.Event.AggregateID()
+	}
+
 	ctx = context.WithValue(ctx, streamIDKey, env.StreamID)
-	ctx = context.WithValue(ctx, aggregateIDKey, env.Event.AggregateID())
+	ctx = context.WithValue(ctx, aggregateIDKey, aggregateID)
 	ctx = context.WithValue(ctx, eventIDKey, env.EventID)
 	ctx = context.WithValue(ctx, versionKey, env.Version)
 	ctx = context.WithValue(ctx, globalVersionKey, env.GlobalVersion)

--- a/context_test.go
+++ b/context_test.go
@@ -172,3 +172,23 @@ func TestContextGetters(t *testing.T) {
 		})
 	}
 }
+
+// TestWithEnvelope_NilEvent is a regression test for GitHub issue #60:
+// WithEnvelope called env.Event.AggregateID() with no nil check, panicking
+// on an Envelope whose Event is nil, unlike every other *FromContext getter
+// in this file, which degrades gracefully to a documented zero value.
+func TestWithEnvelope_NilEvent(t *testing.T) {
+	env := &Envelope{
+		StreamID: "some-stream",
+		Event:    nil,
+	}
+
+	ctx := WithEnvelope(t.Context(), env)
+
+	if got := AggregateIDFromContext(ctx); got != "" {
+		t.Errorf("AggregateIDFromContext() = %q, want \"\"", got)
+	}
+	if got := StreamIDFromContext(ctx); got != "some-stream" {
+		t.Errorf("StreamIDFromContext() = %q, want %q", got, "some-stream")
+	}
+}


### PR DESCRIPTION
## Summary
- `WithEnvelope` called `env.Event.AggregateID()` with no nil check, panicking on an `Envelope` whose `Event` is nil. Every other `*FromContext` getter in `context.go` degrades gracefully to a documented zero value instead of panicking.
- Nil-checked `env.Event` and defaulted the aggregate ID to `""` to match, consistent with `AggregateIDFromContext`'s own documented zero value.

Fixes #60

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (164, up from 163)
- [x] Added `TestWithEnvelope_NilEvent` (adapted from the issue's repro). Verified it actually catches the bug: reverted the fix, confirmed the test panics exactly as described, then restored the fix and confirmed it passes