### PR TITLE
Fix WithCommandTelemetry aliasing a shared attribute slice

### DIFF
--- a/otel/command_handler.go
+++ b/otel/command_handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/terraskye/eventsourcing"
@@ -141,7 +142,11 @@ func WithCommandTelemetry[C eventsourcing.Command](next eventsourcing.CommandHan
 
 	return func(ctx context.Context, cmd C) (eventsourcing.AppendResult, error) {
 		ctx = eventsourcing.WithCausation(ctx, commandType)
-		attr := append(baseAttributes, AttrAggregateID.String(cmd.AggregateID()))
+		// Clone before appending: baseAttributes is shared across every call
+		// to this handler, and appending directly to it would alias its
+		// backing array across concurrent calls whenever it has spare
+		// capacity, racing on it (see GitHub issue #59).
+		attr := append(slices.Clone(baseAttributes), AttrAggregateID.String(cmd.AggregateID()))
 
 		if cfg.GetAttributes != nil {
 			attr = append(attr, cfg.GetAttributes(ctx)...)

--- a/otel/command_handler_test.go
+++ b/otel/command_handler_test.go
@@ -2,9 +2,12 @@ package otel
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/terraskye/eventsourcing"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type panicProbeCmd struct{}
@@ -45,4 +48,38 @@ func TestWithCommandTelemetry_ZeroValueBusinessViolationDoesNotPanic(t *testing.
 	if err == nil {
 		t.Fatalf("expected the business rule violation to be returned")
 	}
+}
+
+type raceProbeCmd struct{ id string }
+
+func (c raceProbeCmd) AggregateID() string { return c.id }
+
+// TestWithCommandTelemetry_ConcurrentCallsRaceOnSharedBaseAttributes is a
+// regression test for GitHub issue #59: baseAttributes was built once,
+// outside the returned handler closure, and every call appended directly to
+// it. Once cfg.Attributes was large enough to leave baseAttributes with
+// spare capacity (11 static attributes reproduces it reliably), concurrent
+// calls raced on its shared backing array instead of each getting an
+// independent slice.
+func TestWithCommandTelemetry_ConcurrentCallsRaceOnSharedBaseAttributes(t *testing.T) {
+	extra := make([]attribute.KeyValue, 11)
+	for i := range extra {
+		extra[i] = attribute.String(fmt.Sprintf("k%d", i), "v")
+	}
+
+	next := func(ctx context.Context, cmd raceProbeCmd) (eventsourcing.AppendResult, error) {
+		return eventsourcing.AppendResult{StreamID: cmd.id}, nil
+	}
+
+	handler := WithCommandTelemetry[raceProbeCmd](next, WithAttributes(extra...))
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, _ = handler(context.Background(), raceProbeCmd{id: fmt.Sprintf("agg-%d", i)})
+		}(i)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## Summary
- `baseAttributes` was built once, outside the returned handler closure, and every call appended directly to it (`append(baseAttributes, AttrAggregateID.String(...))`). Once `cfg.Attributes` was large enough to leave `baseAttributes` with spare capacity, concurrent calls raced on its shared backing array instead of each getting an independent slice — one call's attributes (aggregate ID, stream ID/version) could be silently overwritten by another's before being read.
- Cloned `baseAttributes` before appending, so every call starts from its own independent slice — the same `Clone`-before-append idiom used for the `maps.Clone` fix to the analogous shared metadata map bug (#24), applied to this shared attribute slice.

Fixes #59

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (165, up from 164)
- [x] Added `TestWithCommandTelemetry_ConcurrentCallsRaceOnSharedBaseAttributes` (adapted from the issue's repro). Verified it actually catches the bug: reverted the fix, confirmed the race at exactly the line the issue describes, then restored the fix and confirmed 20/20 clean under `-race`