### PR TITLE
Fix telemetry middlewares recording milliseconds into second-unit histograms

### DIFF
--- a/otel/command_handler.go
+++ b/otel/command_handler.go
@@ -65,7 +65,7 @@ func CommandTelemetry(options ...Option) eventsourcing.CommandHandlerMiddleware 
 				AttrStreamID.String(result.StreamID),
 				AttrStreamVersion.Int64(int64(result.NextExpectedVersion)),
 			)
-			CommandsDuration.Record(ctx, float64(time.Since(startTime).Milliseconds()), metric.WithAttributes(AttrCommandType.String(commandType)))
+			CommandsDuration.Record(ctx, time.Since(startTime).Seconds(), metric.WithAttributes(AttrCommandType.String(commandType)))
 			span.SetAttributes(attr...)
 
 			if err != nil {

--- a/otel/command_handler_test.go
+++ b/otel/command_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/terraskye/eventsourcing"
 	"go.opentelemetry.io/otel/attribute"
@@ -82,4 +83,74 @@ func TestWithCommandTelemetry_ConcurrentCallsRaceOnSharedBaseAttributes(t *testi
 		}(i)
 	}
 	wg.Wait()
+}
+
+type durationTestCommand struct{}
+
+func (durationTestCommand) AggregateID() string { return "agg-1" }
+
+// TestCommandTelemetryDurationRecordedInSeconds is a regression test for
+// GitHub issue #57: CommandTelemetry recorded
+// time.Since(startTime).Milliseconds() into eventsourcing.commands.duration,
+// but the instrument declares metric.WithUnit("s") and second-scaled bucket
+// boundaries — every sample from the middleware path was 1000x too large,
+// and any operation faster than 1ms recorded as exactly 0 (Milliseconds()
+// truncates to an integer). WithCommandTelemetry was already correct, using
+// .Seconds().
+func TestCommandTelemetryDurationRecordedInSeconds(t *testing.T) {
+	rec := durationRecorder
+
+	const work = 50 * time.Millisecond
+	const instrument = "eventsourcing.commands.duration"
+
+	tests := []struct {
+		name   string
+		invoke func(t *testing.T)
+	}{
+		{
+			name: "CommandTelemetry middleware",
+			invoke: func(t *testing.T) {
+				h := CommandTelemetry()(func(ctx context.Context, cmd eventsourcing.Command) (eventsourcing.AppendResult, error) {
+					time.Sleep(work)
+					return eventsourcing.AppendResult{Successful: true}, nil
+				})
+				if _, err := h(context.Background(), durationTestCommand{}); err != nil {
+					t.Fatalf("command: %v", err)
+				}
+			},
+		},
+		{
+			name: "WithCommandTelemetry decorator",
+			invoke: func(t *testing.T) {
+				h := WithCommandTelemetry(func(ctx context.Context, cmd durationTestCommand) (eventsourcing.AppendResult, error) {
+					time.Sleep(work)
+					return eventsourcing.AppendResult{Successful: true}, nil
+				})
+				if _, err := h(context.Background(), durationTestCommand{}); err != nil {
+					t.Fatalf("command: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(rec.valuesFor(instrument))
+			tc.invoke(t)
+			got := rec.valuesFor(instrument)
+			if len(got) != before+1 {
+				t.Fatalf("expected exactly one new %s sample, got %d", instrument, len(got)-before)
+			}
+
+			v := got[len(got)-1]
+			if v >= 1 {
+				t.Errorf("%s recorded %v for a %v operation; the instrument declares unit \"s\", so it should be ~%v",
+					instrument, v, work, work.Seconds())
+			}
+			if v < work.Seconds()*0.5 {
+				t.Errorf("%s recorded %v for a %v operation; expected ~%v seconds",
+					instrument, v, work, work.Seconds())
+			}
+		})
+	}
 }

--- a/otel/otel_test.go
+++ b/otel/otel_test.go
@@ -1,0 +1,92 @@
+package otel
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	otelapi "go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/embedded"
+	"go.opentelemetry.io/otel/metric/noop"
+)
+
+// durationRecorder captures every value recorded through this package's
+// duration histograms for the lifetime of the test binary.
+//
+// OTel's global meter only delegates a package-level instrument (created
+// once, at package init, via meter.Float64Histogram) to a real provider the
+// first time one is installed with otel.SetMeterProvider — a later call
+// does not rebind an instrument that has already resolved. Tests that need
+// to read back recorded values must therefore share one recMeterProvider,
+// installed exactly once here, rather than each calling SetMeterProvider
+// with its own recorder.
+var durationRecorder = &recorder{}
+
+func TestMain(m *testing.M) {
+	otelapi.SetMeterProvider(recMeterProvider{rec: durationRecorder})
+	os.Exit(m.Run())
+}
+
+// recorder captures histogram values recorded through a recMeterProvider,
+// for tests that need to assert on the actual value a *Duration.Record call
+// writes rather than just that it was called.
+type histRecord struct {
+	name  string
+	value float64
+}
+
+type recorder struct {
+	mu      sync.Mutex
+	records []histRecord
+}
+
+func (r *recorder) add(name string, v float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.records = append(r.records, histRecord{name: name, value: v})
+}
+
+func (r *recorder) valuesFor(name string) []float64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]float64, 0, len(r.records))
+	for _, rec := range r.records {
+		if rec.name == name {
+			out = append(out, rec.value)
+		}
+	}
+	return out
+}
+
+type recHistogram struct {
+	noop.Float64Histogram
+	name string
+	rec  *recorder
+}
+
+func (h recHistogram) Record(_ context.Context, v float64, _ ...metric.RecordOption) {
+	h.rec.add(h.name, v)
+}
+
+type recMeter struct {
+	noop.Meter
+	rec *recorder
+}
+
+func (m recMeter) Float64Histogram(name string, _ ...metric.Float64HistogramOption) (metric.Float64Histogram, error) {
+	return recHistogram{name: name, rec: m.rec}, nil
+}
+
+// recMeterProvider is a [metric.MeterProvider] that records every
+// Float64Histogram value it's asked to record, for tests to assert on
+// afterward. Everything else it produces is a no-op.
+type recMeterProvider struct {
+	embedded.MeterProvider
+	rec *recorder
+}
+
+func (p recMeterProvider) Meter(_ string, _ ...metric.MeterOption) metric.Meter {
+	return recMeter{rec: p.rec}
+}

--- a/otel/query_handler.go
+++ b/otel/query_handler.go
@@ -59,7 +59,7 @@ func QueryTelemetry(options ...Option) eventsourcing.QueryHandlerMiddleware {
 			startTime := time.Now()
 			result, err := next(ctx, qry)
 
-			QueriesDuration.Record(ctx, float64(time.Since(startTime).Milliseconds()), metric.WithAttributes(AttrQueryType.String(queryType)))
+			QueriesDuration.Record(ctx, time.Since(startTime).Seconds(), metric.WithAttributes(AttrQueryType.String(queryType)))
 
 			if err != nil {
 				span.SetStatus(codes.Error, err.Error())

--- a/otel/query_handler_test.go
+++ b/otel/query_handler_test.go
@@ -1,0 +1,80 @@
+package otel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/terraskye/eventsourcing"
+)
+
+type durationTestQuery struct{}
+
+func (durationTestQuery) ID() []byte { return []byte("q-1") }
+
+// TestQueryTelemetryDurationRecordedInSeconds is a regression test for
+// GitHub issue #57: QueryTelemetry recorded
+// time.Since(startTime).Milliseconds() into eventsourcing.queries.duration,
+// but the instrument declares metric.WithUnit("s") and second-scaled bucket
+// boundaries — every sample from the middleware path was 1000x too large,
+// and any operation faster than 1ms recorded as exactly 0 (Milliseconds()
+// truncates to an integer). WithQueryTelemetry was already correct, using
+// .Seconds().
+func TestQueryTelemetryDurationRecordedInSeconds(t *testing.T) {
+	rec := durationRecorder
+
+	const work = 50 * time.Millisecond
+	const instrument = "eventsourcing.queries.duration"
+
+	tests := []struct {
+		name   string
+		invoke func(t *testing.T)
+	}{
+		{
+			name: "QueryTelemetry middleware",
+			invoke: func(t *testing.T) {
+				h := QueryTelemetry()(func(ctx context.Context, qry eventsourcing.Query) (any, error) {
+					time.Sleep(work)
+					return "ok", nil
+				})
+				if _, err := h(context.Background(), durationTestQuery{}); err != nil {
+					t.Fatalf("query: %v", err)
+				}
+			},
+		},
+		{
+			name: "WithQueryTelemetry decorator",
+			invoke: func(t *testing.T) {
+				h := WithQueryTelemetry(eventsourcing.NewQueryHandlerFunc(
+					func(ctx context.Context, qry durationTestQuery) (string, error) {
+						time.Sleep(work)
+						return "ok", nil
+					}))
+				if _, err := h.HandleQuery(context.Background(), durationTestQuery{}); err != nil {
+					t.Fatalf("query: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			before := len(rec.valuesFor(instrument))
+			tc.invoke(t)
+			got := rec.valuesFor(instrument)
+			if len(got) != before+1 {
+				t.Fatalf("expected exactly one new %s sample, got %d", instrument, len(got)-before)
+			}
+
+			v := got[len(got)-1]
+			if v >= 1 {
+				t.Errorf("%s recorded %v for a %v operation; the instrument declares unit \"s\", so it should be ~%v",
+					instrument, v, work, work.Seconds())
+			}
+			if v < work.Seconds()*0.5 {
+				t.Errorf("%s recorded %v for a %v operation; expected ~%v seconds",
+					instrument, v, work, work.Seconds())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `CommandTelemetry` and `QueryTelemetry` recorded `time.Since(startTime).Milliseconds()` into `eventsourcing.commands.duration` / `eventsourcing.queries.duration`, but both instruments declare `metric.WithUnit("s")` and second-scaled bucket boundaries. Every sample from the middleware path was 1000x too large, and any operation faster than 1ms recorded as exactly 0 (`Milliseconds()` truncates to an integer). The decorator equivalents (`WithCommandTelemetry`, `WithQueryTelemetry`) already used `.Seconds()` correctly.
- Record `.Seconds()` in both middlewares instead, matching every other `*Duration.Record` call site in the package.

Fixes #57

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (170, up from 165)
- [x] Added a regression test per source file (`command_handler_test.go`, `query_handler_test.go`), adapted from the issue's repro. Sharing the recording `MeterProvider` mock via a single `TestMain` in a new `otel_test.go`: OTel's global meter only delegates a package-level instrument to a real provider the first time one is installed, so two independent `SetMeterProvider` calls across separate test functions don't both take effect — discovered this while splitting the test to match `<filename>_test.go` per source file.
- [x] Verified both regression tests actually catch the bug: reverted the fix, confirmed each fails independently with the exact issue-reported symptom (`recorded 50 for a 50ms operation`), then restored the fix and confirmed all pass