### PR TITLE
Fix kurrentdb EventBus.Subscribe leaking a ctx-watcher goroutine per call

### DIFF
--- a/eventbus/kurrentdb/eventbus.go
+++ b/eventbus/kurrentdb/eventbus.go
@@ -76,7 +76,9 @@ func (b *EventBus) Use(middlewares ...cqrs.EventHandlerMiddleware) {
 // a subscription that already exists in KurrentDB. It returns an error if
 // handler is nil, the bus is already closed, name is already registered, or
 // the subscription could not be ensured. The subscription is removed from
-// the bus automatically when ctx is canceled.
+// the bus automatically when ctx is canceled, or when the bus is closed —
+// neither leaves a goroutine behind, even if ctx is long-lived (e.g.
+// context.Background()).
 func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.EventHandler, opts ...cqrs.SubscriberOption) error {
 	if handler == nil {
 		return errors.New("filter and handler cannot be nil")
@@ -98,7 +100,7 @@ func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.Even
 	}
 	handler = wrapped
 
-	workerCtx, cancel := context.WithCancel(context.Background())
+	workerCtx, cancel := context.WithCancel(ctx)
 
 	opt := kurrentdb.PersistentAllSubscriptionOptions{}
 
@@ -120,9 +122,16 @@ func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.Even
 	b.wg.Add(1)
 	go b.runSubscriber(workerCtx, sub)
 
-	// Remove subscriber when caller context is done
+	// workerCtx is a child of ctx, so its Done channel closes whenever
+	// either the caller cancels ctx (auto-unsubscribe) or Close/
+	// removeSubscriber calls cancel directly — one signal to watch for
+	// both triggers, rather than parking on the caller's ctx alone, which
+	// never fires (and leaks this goroutine) for a long-lived ctx such as
+	// context.Background().
+	b.wg.Add(1)
 	go func() {
-		<-ctx.Done()
+		defer b.wg.Done()
+		<-workerCtx.Done()
 		b.removeSubscriber(name)
 	}()
 

--- a/eventbus/kurrentdb/eventbus_test.go
+++ b/eventbus/kurrentdb/eventbus_test.go
@@ -1,0 +1,121 @@
+package kurrentdb_test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	cqrs "github.com/terraskye/eventsourcing"
+	kdbbus "github.com/terraskye/eventsourcing/eventbus/kurrentdb"
+
+	"github.com/kurrent-io/KurrentDB-Client-Go/kurrentdb"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+)
+
+type leakEvent struct{}
+
+func (leakEvent) AggregateID() string { return "leak" }
+func (leakEvent) EventType() string   { return "leakEvent" }
+
+var testDB *kurrentdb.Client
+
+// TestMain starts a single kurrentdb container for every test in this
+// package, so each test doesn't pay its own container-startup cost.
+func TestMain(m *testing.M) {
+	cqrs.RegisterEventByType(func() cqrs.Event { return &leakEvent{} })
+
+	ctx := context.Background()
+	req := testcontainers.ContainerRequest{
+		Image:        "kurrentplatform/kurrentdb:latest",
+		ExposedPorts: []string{"2113/tcp"},
+		Env: map[string]string{
+			"EVENTSTORE_INSECURE":        "true",
+			"EVENTSTORE_RUN_PROJECTIONS": "None",
+			"EVENTSTORE_MEM_DB":          "true",
+			"EVENTSTORE_CLUSTER_SIZE":    "1",
+		},
+		WaitingFor: wait.ForLog("IS LEADER... SPARTA!").WithStartupTimeout(60 * time.Second),
+	}
+	kc, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: req,
+		Started:          true,
+	})
+	if err != nil {
+		log.Fatalf("start kurrentdb container: %v", err)
+	}
+	defer kc.Terminate(ctx) //nolint:errcheck
+
+	host, err := kc.Host(ctx)
+	if err != nil {
+		log.Fatalf("get host: %v", err)
+	}
+	port, err := kc.MappedPort(ctx, "2113")
+	if err != nil {
+		log.Fatalf("get port: %v", err)
+	}
+
+	settings, err := kurrentdb.ParseConnectionString(fmt.Sprintf("esdb://%s:%s?tls=false", host, port.Port()))
+	if err != nil {
+		log.Fatalf("parse connection string: %v", err)
+	}
+	testDB, err = kurrentdb.NewClient(settings)
+	if err != nil {
+		log.Fatalf("new client: %v", err)
+	}
+
+	os.Exit(m.Run())
+}
+
+func countGoroutinesCreatedBy(substr string) int {
+	buf := make([]byte, 4<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), substr)
+}
+
+// TestSubscribe_CtxWatcherGoroutineLeaksAfterClose is a regression test for
+// GitHub issue #29: the goroutine that auto-removes a subscriber blocked on
+// <-ctx.Done() alone, which never fires for a long-lived ctx such as
+// context.Background() (used by every other test/example in this repo) —
+// leaking one goroutine per Subscribe call for the rest of the process's
+// life, unaffected by Close.
+func TestSubscribe_CtxWatcherGoroutineLeaksAfterClose(t *testing.T) {
+	const n = 10
+	const createdBy = "created by github.com/terraskye/eventsourcing/eventbus/kurrentdb.(*EventBus).Subscribe"
+
+	bus := kdbbus.NewEventBus(testDB, 50)
+
+	handler := cqrs.NewEventHandlerFunc(func(ctx context.Context, event cqrs.Event) error {
+		return nil
+	})
+
+	before := countGoroutinesCreatedBy(createdBy)
+
+	for i := 0; i < n; i++ {
+		name := "leak-sub-" + strconv.Itoa(i)
+		if err := bus.Subscribe(context.Background(), name, handler); err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+	}
+
+	if err := bus.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Give any well-behaved goroutines a chance to exit.
+	time.Sleep(500 * time.Millisecond)
+	runtime.GC()
+
+	after := countGoroutinesCreatedBy(createdBy)
+
+	leaked := after - before
+	if leaked > 0 {
+		t.Fatalf("expected 0 leaked ctx-watcher goroutines after Close, got %d (before=%d after=%d)", leaked, before, after)
+	}
+}


### PR DESCRIPTION
## Summary
- The goroutine that auto-removes a subscriber blocked on `<-ctx.Done()` alone, which never fires for a long-lived `ctx` such as `context.Background()` (used by every other test/example in this repo) — leaking one goroutine per `Subscribe` call for the rest of the process's life, unaffected by `Close`.
- `workerCtx` was rooted at `context.Background()`, unrelated to `ctx`. Derived it from `ctx` instead (`context.WithCancel(ctx)`), so its `Done` channel closes whenever either the caller cancels `ctx` or `Close`/`removeSubscriber` cancels it directly, and watch that single signal instead of `ctx` alone. Tracked the watcher goroutine with `b.wg` so `Close`'s `wg.Wait()` actually waits for it, guaranteeing no leak once `Close` returns.
- Same fix already applied to `eventbus/file` (#27).

Fixes #29

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (171 outside `eventbus/kurrentdb`, plus the new container-backed test)
- [x] Added `eventbus/kurrentdb/eventbus_test.go` (new — package had no tests), adapted from the issue's repro against a real `kurrentplatform/kurrentdb` container via testcontainers. Verified it actually catches the bug: reverted the fix, confirmed the test failed with "got 10 (before=0 after=10)" leaked goroutines exactly as the issue describes, then restored the fix and confirmed it passes