### PR TITLE
Fix kurrentdb EventBus Use racing with Subscribe on b.middlewares

### DIFF
--- a/eventbus/kurrentdb/eventbus.go
+++ b/eventbus/kurrentdb/eventbus.go
@@ -60,8 +60,11 @@ func NewEventBus(db *kurrentdb.Client, buffer uint64) *EventBus {
 // Use adds middlewares that wrap every handler registered afterward via
 // Subscribe. As required by [cqrs.EventBus], it must be called before
 // Subscribe: middlewares added after a given subscriber is registered do
-// not apply to that subscriber.
+// not apply to that subscriber. Use and Subscribe are both safe to call
+// concurrently.
 func (b *EventBus) Use(middlewares ...cqrs.EventHandlerMiddleware) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.middlewares = append(b.middlewares, middlewares...)
 }
 
@@ -79,12 +82,6 @@ func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.Even
 		return errors.New("filter and handler cannot be nil")
 	}
 
-	wrapped := handler
-	for i := len(b.middlewares) - 1; i >= 0; i-- {
-		wrapped = b.middlewares[i](wrapped)
-	}
-	handler = wrapped
-
 	b.mu.Lock()
 	if b.closed {
 		b.mu.Unlock()
@@ -94,6 +91,12 @@ func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.Even
 		b.mu.Unlock()
 		return fmt.Errorf("subscriber %q already exists", name)
 	}
+
+	wrapped := handler
+	for i := len(b.middlewares) - 1; i >= 0; i-- {
+		wrapped = b.middlewares[i](wrapped)
+	}
+	handler = wrapped
 
 	workerCtx, cancel := context.WithCancel(context.Background())
 

--- a/eventbus/kurrentdb/use_subscribe_race_test.go
+++ b/eventbus/kurrentdb/use_subscribe_race_test.go
@@ -1,0 +1,51 @@
+package kurrentdb
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	cqrs "github.com/terraskye/eventsourcing"
+)
+
+// TestUse_RacesWithSubscribe is a regression test for GitHub issue #30: Use
+// appended to b.middlewares with no synchronization, and Subscribe read
+// b.middlewares before acquiring b.mu, so calling Use concurrently with
+// Subscribe was a data race under `go test -race`.
+//
+// The bus is closed up front so Subscribe bails out right after building the
+// wrapped handler (reading b.middlewares) and before it ever touches the nil
+// KurrentDB client — this isolates the middlewares race from needing a live
+// server.
+func TestUse_RacesWithSubscribe(t *testing.T) {
+	bus := NewEventBus(nil, 10)
+
+	if err := bus.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	handler := cqrs.NewEventHandlerFunc(func(ctx context.Context, event cqrs.Event) error {
+		return nil
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			bus.Use(func(next cqrs.EventHandler) cqrs.EventHandler {
+				return next
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 1000; i++ {
+			_ = bus.Subscribe(context.Background(), "sub", handler)
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- `Use` appended to `b.middlewares` with no synchronization at all, and `Subscribe` read `b.middlewares` before acquiring `b.mu`, so calling `Use` concurrently with `Subscribe` was a data race under `go test -race` — undefined behavior, not just a stale middleware list.
- Guarded the append in `Use` with `b.mu`, and moved `Subscribe`'s middleware-wrapping loop to after it acquires `b.mu`, reusing the same lock that already guards `subs` and `closed` instead of adding a separate one.
- Same fix already applied to `eventbus/file` (#28).

Fixes #30

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass
- [x] Added `TestUse_RacesWithSubscribe` (adapted from the issue's repro — no live KurrentDB server needed, since the bus is closed up front so `Subscribe` bails out right after reading `b.middlewares`). Verified it actually catches the bug: reverted the fix and reproduced both races the issue describes (2/10 runs), then restored the fix and confirmed 20/20 clean under `-race`