### PR TITLE
Fix Dispatch holding b.mu.RLock() during a blocking channel send

### DIFF
--- a/eventbus/memory/eventbus.go
+++ b/eventbus/memory/eventbus.go
@@ -12,12 +12,16 @@ import (
 
 // subscriber is a single registered handler and its per-handler delivery
 // state: an event-type filter and a buffered channel served by its own
-// worker goroutine.
+// worker goroutine. ctx is never explicitly canceled by anyone but cancel,
+// and its Done channel is the only shutdown signal for this subscriber —
+// events is never closed, so Dispatch can safely send to it without holding
+// b.mu (see Dispatch).
 type subscriber struct {
 	name    string
 	handler cqrs.EventHandler
 	filter  *filter
 	events  chan *cqrs.Envelope
+	ctx     context.Context
 	cancel  context.CancelFunc
 }
 
@@ -99,6 +103,7 @@ func (b *EventBus) Subscribe(
 			events: make([]string, 0),
 		},
 		events: make(chan *cqrs.Envelope, b.bufferSize),
+		ctx:    workerCtx,
 		cancel: cancel,
 	}
 
@@ -138,10 +143,10 @@ func (b *EventBus) Close() error {
 	}
 	b.closed = true
 
-	// Close all subscribers
+	// Cancel every subscriber. events is deliberately never closed — see
+	// subscriber and Dispatch.
 	for name, s := range b.subs {
 		s.cancel()
-		close(s.events)
 		delete(b.subs, name)
 	}
 	b.mu.Unlock()
@@ -156,7 +161,7 @@ func (b *EventBus) Close() error {
 }
 
 // runSubscriber delivers events from s.events to s.handler until ctx is
-// canceled or s.events is closed by Close or removeSubscriber.
+// canceled by Close or removeSubscriber.
 func (b *EventBus) runSubscriber(ctx context.Context, s *subscriber) {
 	defer b.wg.Done()
 
@@ -165,11 +170,7 @@ func (b *EventBus) runSubscriber(ctx context.Context, s *subscriber) {
 		case <-ctx.Done():
 			return
 
-		case ev, ok := <-s.events:
-			if !ok {
-				return
-			}
-
+		case ev := <-s.events:
 			// Handle event
 			if err := s.handler.Handle(cqrs.WithEnvelope(ctx, ev), ev.Event); err != nil {
 				select {
@@ -195,7 +196,6 @@ func (b *EventBus) removeSubscriber(name string) {
 	b.mu.Unlock()
 
 	s.cancel()
-	close(s.events)
 }
 
 // Dispatch delivers ev to every subscriber whose event-type filter matches
@@ -204,20 +204,32 @@ func (b *EventBus) removeSubscriber(name string) {
 // delivered them, on that subscriber's own goroutine, but Dispatch itself
 // blocks until ev is queued for every matching subscriber — a subscriber
 // whose buffer is full therefore delays the caller until its handler
-// catches up. Dispatch is a no-op once the bus has been closed.
+// catches up, though never past that subscriber's own removal or the bus
+// being closed. Dispatch is a no-op once the bus has been closed.
 func (b *EventBus) Dispatch(ev *cqrs.Envelope) {
 	b.mu.RLock()
-	defer b.mu.RUnlock()
 	if b.closed {
+		b.mu.RUnlock()
 		return
 	}
-
+	matched := make([]*subscriber, 0, len(b.subs))
 	for _, s := range b.subs {
-
 		if len(s.filter.events) == 0 || slices.Contains(s.filter.events, ev.Event.EventType()) {
-			select {
-			case s.events <- ev:
-			}
+			matched = append(matched, s)
+		}
+	}
+	b.mu.RUnlock()
+
+	// The blocking send below must not run while holding b.mu: a subscriber
+	// whose buffer is full (or whose handler is stuck) would otherwise block
+	// Close and every other Dispatch call, not just this one. The select's
+	// second case bounds the wait to that subscriber's own lifetime, so a
+	// subscriber removed (or the bus closed) while this send is pending is
+	// given up on instead of blocking forever with nothing left to drain it.
+	for _, s := range matched {
+		select {
+		case s.events <- ev:
+		case <-s.ctx.Done():
 		}
 	}
 }

--- a/eventbus/memory/eventbus_test.go
+++ b/eventbus/memory/eventbus_test.go
@@ -1,0 +1,94 @@
+package memory
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	cqrs "github.com/terraskye/eventsourcing"
+)
+
+type blockingEvent struct{}
+
+func (blockingEvent) AggregateID() string { return "agg-1" }
+func (blockingEvent) EventType() string   { return "blockingEvent" }
+
+type blockingHandler struct {
+	handling     chan struct{}
+	handlingOnce sync.Once
+	release      chan struct{}
+}
+
+func (h *blockingHandler) Handle(ctx context.Context, ev cqrs.Event) error {
+	h.handlingOnce.Do(func() { close(h.handling) })
+	<-h.release
+	return nil
+}
+
+// TestDispatch_BlockingSendDoesNotHoldLock is a regression test for GitHub
+// issue #31: Dispatch performed a blocking send to a subscriber's channel
+// while still holding b.mu.RLock(). A slow or stuck handler left that send
+// (and the RLock) pending forever, deadlocking Close (which needs
+// b.mu.Lock()) and every other call that needs the lock — not just the one
+// Dispatch call for the slow subscriber.
+func TestDispatch_BlockingSendDoesNotHoldLock(t *testing.T) {
+	bus := NewEventBus(0) // unbuffered subscriber channel
+
+	h := &blockingHandler{
+		handling: make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+
+	if err := bus.Subscribe(context.Background(), "sub1", h); err != nil {
+		t.Fatalf("Subscribe: %v", err)
+	}
+
+	// First event: runSubscriber's select receives it immediately (synchronous
+	// handoff on the unbuffered channel) and calls Handle, which blocks on
+	// h.release. This first Dispatch call itself returns fine.
+	bus.Dispatch(&cqrs.Envelope{Event: blockingEvent{}})
+
+	select {
+	case <-h.handling:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler never started")
+	}
+
+	// Second event: runSubscriber is busy inside Handle and not receiving
+	// from s.events, and the channel is unbuffered, so this send blocks. It
+	// must not do so while holding b.mu.
+	go bus.Dispatch(&cqrs.Envelope{Event: blockingEvent{}})
+	time.Sleep(200 * time.Millisecond)
+
+	// A completely unrelated call that needs b.mu.Lock() must not be blocked
+	// by the pending send above.
+	subscribeDone := make(chan error, 1)
+	go func() {
+		subscribeDone <- bus.Subscribe(context.Background(), "sub2", cqrs.NewEventHandlerFunc(
+			func(ctx context.Context, ev cqrs.Event) error { return nil },
+		))
+	}()
+
+	select {
+	case err := <-subscribeDone:
+		if err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Subscribe was blocked by the pending Dispatch send — b.mu is still held during the blocking send")
+	}
+
+	close(h.release)
+
+	closeDone := make(chan struct{})
+	go func() {
+		_ = bus.Close()
+		close(closeDone)
+	}()
+	select {
+	case <-closeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not complete after the handler was released")
+	}
+}


### PR DESCRIPTION
## Summary
- `Dispatch` sent to each matching subscriber's channel while still holding `b.mu.RLock()`. A slow or stuck handler left that blocking send (and the RLock) pending forever, deadlocking `Close` (which needs `b.mu.Lock()`) and every other call needing the lock — not just the one `Dispatch` call for the slow subscriber.
- Snapshot the matching subscribers under `RLock`, release it, then do the (possibly blocking) sends outside the lock.
- Since a subscriber's channel is no longer closed by `Close`/`removeSubscriber` (canceling its context is now the only shutdown signal — it was already one of `runSubscriber`'s `select` cases, so closing the channel too was redundant, and would race with `Dispatch`'s send now that it runs unlocked), each send instead selects on the subscriber's own context being done, so a subscriber removed or the bus closed while a send is pending is given up on rather than blocked on forever with nothing left to drain it. Legitimate backpressure to a slow-but-still-alive subscriber is unaffected.

Fixes #31

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (172, up from 171)
- [x] Added `eventbus/memory/eventbus_test.go` (new — package had no tests), adapted from the issue's repro. Verified it actually catches the bug: reverted the fix, confirmed the test failed at exactly the assertion proving the mutex is held during the blocking send, then restored the fix and confirmed 20/20 clean under `-race`