### PR TITLE
Fix memory EventBus.Subscribe leaking a ctx-watcher goroutine per call

### DIFF
--- a/eventbus/memory/eventbus.go
+++ b/eventbus/memory/eventbus.go
@@ -70,7 +70,9 @@ func (b *EventBus) Use(middlewares ...cqrs.EventHandlerMiddleware) {
 // default a subscriber receives every event; pass [WithFilterEvents] to
 // restrict delivery to specific event types. It returns an error if handler
 // is nil, the bus is already closed, or name is already registered. The
-// subscription is removed automatically when ctx is canceled.
+// subscription is removed automatically when ctx is canceled, or when the
+// bus is closed — neither leaves a goroutine behind, even if ctx is
+// long-lived (e.g. context.Background()).
 func (b *EventBus) Subscribe(
 	ctx context.Context,
 	name string,
@@ -98,7 +100,7 @@ func (b *EventBus) Subscribe(
 	}
 	handler = wrapped
 
-	workerCtx, cancel := context.WithCancel(context.Background())
+	workerCtx, cancel := context.WithCancel(ctx)
 	s := &subscriber{
 		name:    name,
 		handler: handler,
@@ -120,9 +122,16 @@ func (b *EventBus) Subscribe(
 	b.wg.Add(1)
 	go b.runSubscriber(workerCtx, s)
 
-	// Automatically remove when caller’s ctx finishes
+	// workerCtx is a child of ctx, so its Done channel closes whenever
+	// either the caller cancels ctx (auto-unsubscribe) or Close/
+	// removeSubscriber calls cancel directly — one signal to watch for
+	// both triggers, rather than parking on the caller's ctx alone, which
+	// never fires (and leaks this goroutine) for a long-lived ctx such as
+	// context.Background().
+	b.wg.Add(1)
 	go func() {
-		<-ctx.Done()
+		defer b.wg.Done()
+		<-workerCtx.Done()
 		b.removeSubscriber(name)
 	}()
 

--- a/eventbus/memory/eventbus_internal_test.go
+++ b/eventbus/memory/eventbus_internal_test.go
@@ -1,0 +1,57 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	cqrs "github.com/terraskye/eventsourcing"
+)
+
+func countGoroutinesCreatedBy(substr string) int {
+	buf := make([]byte, 4<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), substr)
+}
+
+// TestSubscribe_CtxWatcherGoroutineLeaksAfterClose is a regression test for
+// GitHub issue #32: the goroutine that auto-removes a subscriber blocked on
+// <-ctx.Done() alone, which never fires for a long-lived ctx such as
+// context.Background() (used by every other test/example in this repo) —
+// leaking one goroutine per Subscribe call for the rest of the process's
+// life, unaffected by Close.
+func TestSubscribe_CtxWatcherGoroutineLeaksAfterClose(t *testing.T) {
+	const n = 50
+	const createdBy = "created by github.com/terraskye/eventsourcing/eventbus/memory.(*EventBus).Subscribe"
+
+	bus := NewEventBus(1)
+
+	before := countGoroutinesCreatedBy(createdBy)
+
+	noop := cqrs.NewEventHandlerFunc(func(ctx context.Context, ev cqrs.Event) error { return nil })
+
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("sub-%d", i)
+		if err := bus.Subscribe(context.Background(), name, noop); err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+	}
+
+	if err := bus.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Give any well-behaved goroutines a chance to exit.
+	time.Sleep(200 * time.Millisecond)
+	runtime.GC()
+
+	after := countGoroutinesCreatedBy(createdBy)
+
+	leaked := after - before
+	if leaked > 0 {
+		t.Fatalf("expected 0 leaked ctx-watcher goroutines after Close, got %d (before=%d after=%d)", leaked, before, after)
+	}
+}


### PR DESCRIPTION
## Summary
- The goroutine that auto-removes a subscriber blocked on `<-ctx.Done()` alone, which never fires for a long-lived `ctx` such as `context.Background()` (used by every other test/example in this repo) — leaking one goroutine per `Subscribe` call for the rest of the process's life, unaffected by `Close`.
- `workerCtx` was rooted at `context.Background()`, unrelated to `ctx`. Derived it from `ctx` instead (`context.WithCancel(ctx)`), so its `Done` channel closes whenever either the caller cancels `ctx` or `Close`/`removeSubscriber` cancels it directly, and watch that single signal instead of `ctx` alone. Tracked the watcher goroutine with `b.wg` so `Close`'s `wg.Wait()` actually waits for it, guaranteeing no leak once `Close` returns.
- Same fix already applied to `eventbus/file` (#27) and `eventbus/kurrentdb` (#29).

Fixes #32

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (172)
- [x] Added `eventbus/memory/eventbus_test.go` (new — package had no tests), adapted from the issue's repro. Verified it actually catches the bug: reverted the fix, confirmed "got 50 (before=0 after=50)" leaked goroutines exactly as the issue describes, then restored the fix and confirmed it passes