### PR TITLE
Fix memory EventBus Use racing with Subscribe on b.middlewares

### DIFF
--- a/eventbus/memory/eventbus.go
+++ b/eventbus/memory/eventbus.go
@@ -54,8 +54,11 @@ func NewEventBus(bufferSize int) *EventBus {
 // Use adds middlewares that wrap every handler registered afterward via
 // Subscribe. As required by [cqrs.EventBus], it must be called before
 // Subscribe: middlewares added after a given subscriber is registered do
-// not apply to that subscriber.
+// not apply to that subscriber. Use and Subscribe are both safe to call
+// concurrently.
 func (b *EventBus) Use(middlewares ...cqrs.EventHandlerMiddleware) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.middlewares = append(b.middlewares, middlewares...)
 }
 
@@ -74,12 +77,6 @@ func (b *EventBus) Subscribe(
 		return errors.New("filter and handler cannot be nil")
 	}
 
-	wrapped := handler
-	for i := len(b.middlewares) - 1; i >= 0; i-- {
-		wrapped = b.middlewares[i](wrapped)
-	}
-	handler = wrapped
-
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -90,6 +87,12 @@ func (b *EventBus) Subscribe(
 	if _, exists := b.subs[name]; exists {
 		return fmt.Errorf("handler with name %q already registered", name)
 	}
+
+	wrapped := handler
+	for i := len(b.middlewares) - 1; i >= 0; i-- {
+		wrapped = b.middlewares[i](wrapped)
+	}
+	handler = wrapped
 
 	workerCtx, cancel := context.WithCancel(context.Background())
 	s := &subscriber{

--- a/eventbus/memory/use_subscribe_race_test.go
+++ b/eventbus/memory/use_subscribe_race_test.go
@@ -1,0 +1,40 @@
+package memory_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	cqrs "github.com/terraskye/eventsourcing"
+	"github.com/terraskye/eventsourcing/eventbus/memory"
+)
+
+// TestUse_RacesWithSubscribe is a regression test for GitHub issue #33: Use
+// appended to b.middlewares with no synchronization at all, and Subscribe
+// read b.middlewares before acquiring b.mu, so calling Use concurrently with
+// Subscribe was a data race under `go test -race`.
+func TestUse_RacesWithSubscribe(t *testing.T) {
+	bus := memory.NewEventBus(1)
+
+	noopMiddleware := func(next cqrs.EventHandler) cqrs.EventHandler {
+		return next
+	}
+	handler := cqrs.NewEventHandlerFunc(func(ctx context.Context, event cqrs.Event) error {
+		return nil
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		bus.Use(noopMiddleware)
+	}()
+
+	go func() {
+		defer wg.Done()
+		_ = bus.Subscribe(context.Background(), "sub-1", handler)
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- `Use` appended to `b.middlewares` with no synchronization at all, and `Subscribe` read `b.middlewares` before acquiring `b.mu`, so calling `Use` concurrently with `Subscribe` was a data race under `go test -race` — undefined behavior, not just a stale middleware list.
- Guarded the append in `Use` with `b.mu`, and moved `Subscribe`'s middleware-wrapping loop to after it acquires `b.mu`, reusing the same lock that already guards `subs` and `closed` instead of adding a separate one.
- Same fix already applied to `eventbus/file` (#28) and `eventbus/kurrentdb` (#30).

Fixes #33

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass
- [x] Added `TestUse_RacesWithSubscribe` (adapted from the issue's repro). Verified it actually catches the bug: reverted the fix, reproduced the race (1/20 runs — a single-shot race, same as the issue's own repro), then restored the fix and confirmed 20/20 clean under `-race`