### PR TITLE
Fix postgres EventBus.Subscribe leaking a ctx-watcher goroutine per call

### DIFF
--- a/eventbus/postgres/eventbus.go
+++ b/eventbus/postgres/eventbus.go
@@ -124,7 +124,9 @@ func (b *EventBus) Use(middlewares ...cqrs.EventHandlerMiddleware) {
 // delivery to specific event types, and [WithStartFrom] to control where a
 // brand-new subscription begins. It returns an error if handler is nil, the
 // bus is already closed, or name is already registered. The subscription is
-// removed automatically when ctx is canceled.
+// removed automatically when ctx is canceled, or when the bus is closed —
+// neither leaves a goroutine behind, even if ctx is long-lived (e.g.
+// context.Background()).
 func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.EventHandler, opts ...cqrs.SubscriberOption) error {
 	if handler == nil {
 		return errors.New("handler cannot be nil")
@@ -151,7 +153,7 @@ func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.Even
 		o(subOpts)
 	}
 
-	workerCtx, cancel := context.WithCancel(context.Background())
+	workerCtx, cancel := context.WithCancel(ctx)
 	sub := &subscriber{
 		name:    name,
 		opts:    *subOpts,
@@ -164,8 +166,16 @@ func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.Even
 	b.wg.Add(1)
 	go b.runSubscriber(workerCtx, sub)
 
+	// workerCtx is a child of ctx, so its Done channel closes whenever
+	// either the caller cancels ctx (auto-unsubscribe) or Close/
+	// removeSubscriber calls cancel directly — one signal to watch for
+	// both triggers, rather than parking on the caller's ctx alone, which
+	// never fires (and leaks this goroutine) for a long-lived ctx such as
+	// context.Background().
+	b.wg.Add(1)
 	go func() {
-		<-ctx.Done()
+		defer b.wg.Done()
+		<-workerCtx.Done()
 		b.removeSubscriber(name)
 	}()
 

--- a/eventbus/postgres/eventbus_subscribe_leak_test.go
+++ b/eventbus/postgres/eventbus_subscribe_leak_test.go
@@ -1,0 +1,61 @@
+package postgres_test
+
+import (
+	"context"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	cqrs "github.com/terraskye/eventsourcing"
+	pgbus "github.com/terraskye/eventsourcing/eventbus/postgres"
+)
+
+func countGoroutinesCreatedBy(substr string) int {
+	buf := make([]byte, 4<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), substr)
+}
+
+// TestSubscribe_CtxWatcherGoroutineLeaksAfterClose is a regression test for
+// GitHub issue #34: the goroutine that auto-removes a subscriber blocked on
+// <-ctx.Done() alone, which never fires for a long-lived ctx such as
+// context.Background() (used by every other test/example in this repo) —
+// leaking one goroutine per Subscribe call for the rest of the process's
+// life, unaffected by Close.
+func TestSubscribe_CtxWatcherGoroutineLeaksAfterClose(t *testing.T) {
+	const n = 20
+	const createdBy = "created by github.com/terraskye/eventsourcing/eventbus/postgres.(*EventBus).Subscribe"
+
+	pool := newPool(t)
+	bus := pgbus.NewEventBus(pool, 50*time.Millisecond)
+
+	handler := cqrs.NewEventHandlerFunc(func(ctx context.Context, event cqrs.Event) error {
+		return nil
+	})
+
+	before := countGoroutinesCreatedBy(createdBy)
+
+	for i := 0; i < n; i++ {
+		name := "leak-sub-" + strconv.Itoa(i)
+		if err := bus.Subscribe(context.Background(), name, handler); err != nil {
+			t.Fatalf("Subscribe: %v", err)
+		}
+	}
+
+	if err := bus.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Give any well-behaved goroutines a chance to exit.
+	time.Sleep(500 * time.Millisecond)
+	runtime.GC()
+
+	after := countGoroutinesCreatedBy(createdBy)
+
+	leaked := after - before
+	if leaked > 0 {
+		t.Fatalf("expected 0 leaked ctx-watcher goroutines after Close, got %d (before=%d after=%d)", leaked, before, after)
+	}
+}


### PR DESCRIPTION
## Summary
- The goroutine that auto-removes a subscriber blocked on `<-ctx.Done()` alone, which never fires for a long-lived `ctx` such as `context.Background()` (used by every other test/example in this repo) — leaking one goroutine per `Subscribe` call for the rest of the process's life, unaffected by `Close`.
- `workerCtx` was rooted at `context.Background()`, unrelated to `ctx`. Derived it from `ctx` instead (`context.WithCancel(ctx)`), so its `Done` channel closes whenever either the caller cancels `ctx` or `Close`/`removeSubscriber` cancels it directly, and watch that single signal instead of `ctx` alone. Tracked the watcher goroutine with `b.wg` so `Close`'s `wg.Wait()` actually waits for it, guaranteeing no leak once `Close` returns.
- Same fix already applied to `eventbus/file` (#27), `eventbus/kurrentdb` (#29), and `eventbus/memory` (#32).

Fixes #34

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass, including all 6 tests in `eventbus/postgres` against a real testcontainers-backed Postgres
- [x] Added `eventbus_subscribe_leak_test.go`, adapted from the issue's repro, reusing the package's existing `newPool`/`TestMain` container infra. Verified it actually catches the bug: reverted the fix, confirmed "got 20" leaked goroutines exactly as the issue describes, then restored the fix and confirmed it passes