### PR TITLE
Fix postgres EventBus Use racing with Subscribe on b.middlewares

### DIFF
--- a/eventbus/postgres/eventbus.go
+++ b/eventbus/postgres/eventbus.go
@@ -112,8 +112,11 @@ func newLockPool(pool *pgxpool.Pool) *pgxpool.Pool {
 // Use adds middlewares that wrap every handler registered afterward via
 // Subscribe. As required by [cqrs.EventBus], it must be called before
 // Subscribe: middlewares added after a given subscriber is registered do
-// not apply to that subscriber.
+// not apply to that subscriber. Use and Subscribe are both safe to call
+// concurrently.
 func (b *EventBus) Use(middlewares ...cqrs.EventHandlerMiddleware) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	b.middlewares = append(b.middlewares, middlewares...)
 }
 
@@ -130,12 +133,6 @@ func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.Even
 		return errors.New("handler cannot be nil")
 	}
 
-	wrapped := handler
-	for i := len(b.middlewares) - 1; i >= 0; i-- {
-		wrapped = b.middlewares[i](wrapped)
-	}
-	handler = wrapped
-
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -145,6 +142,12 @@ func (b *EventBus) Subscribe(ctx context.Context, name string, handler cqrs.Even
 	if _, exists := b.subs[name]; exists {
 		return fmt.Errorf("subscriber %q already exists", name)
 	}
+
+	wrapped := handler
+	for i := len(b.middlewares) - 1; i >= 0; i-- {
+		wrapped = b.middlewares[i](wrapped)
+	}
+	handler = wrapped
 
 	subOpts := &subscriberOptions{}
 	for _, o := range opts {

--- a/eventbus/postgres/use_subscribe_race_test.go
+++ b/eventbus/postgres/use_subscribe_race_test.go
@@ -1,0 +1,49 @@
+package postgres_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	cqrs "github.com/terraskye/eventsourcing"
+	pgbus "github.com/terraskye/eventsourcing/eventbus/postgres"
+)
+
+// TestUse_RacesWithSubscribe is a regression test for GitHub issue #35: Use
+// appended to b.middlewares with no synchronization at all, and Subscribe
+// read b.middlewares before acquiring b.mu, so calling Use concurrently with
+// Subscribe was a data race under `go test -race`.
+func TestUse_RacesWithSubscribe(t *testing.T) {
+	pool := newPool(t)
+	bus := pgbus.NewEventBus(pool, 50*time.Millisecond)
+	t.Cleanup(func() { _ = bus.Close() })
+
+	handler := cqrs.NewEventHandlerFunc(func(ctx context.Context, event cqrs.Event) error {
+		return nil
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			bus.Use(func(next cqrs.EventHandler) cqrs.EventHandler {
+				return next
+			})
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 500; i++ {
+			// Same name every time: only the first call actually registers a
+			// subscriber, but every call reads b.middlewares before that
+			// check, which is enough to race against the writer above.
+			_ = bus.Subscribe(context.Background(), "sub", handler)
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary
- `Use` appended to `b.middlewares` with no synchronization at all, and `Subscribe` read `b.middlewares` before acquiring `b.mu`, so calling `Use` concurrently with `Subscribe` was a data race under `go test -race` — undefined behavior, not just a stale middleware list.
- Guarded the append in `Use` with `b.mu`, and moved `Subscribe`'s middleware-wrapping loop to after it acquires `b.mu`, reusing the same lock that already guards `subs` and `closed` instead of adding a separate one.
- Same fix already applied to `eventbus/file` (#28), `eventbus/kurrentdb` (#30), and `eventbus/memory` (#33).

Fixes #35

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass, including all 6 tests in `eventbus/postgres` against a real testcontainers-backed Postgres
- [x] Added `TestUse_RacesWithSubscribe` (adapted from the issue's repro, reusing the package's existing `newPool` container infra). Verified it actually catches the bug: reverted the fix, reproduced both races the issue describes, then restored the fix and confirmed clean under `-race`