### PR TITLE
Fix a stream named "all" colliding with FilesStore's global symlink dir

### DIFF
--- a/eventstore/file/filestorage.go
+++ b/eventstore/file/filestorage.go
@@ -18,10 +18,21 @@ import (
 
 var _ cqrs.EventStore = (*FilesStore)(nil)
 
+// allDirName is the top-level directory holding the symlink fan-in of every
+// event across all streams, used by [FilesStore.LoadFromAll].
+const allDirName = "all"
+
+// streamsDirName is the top-level directory under which each stream gets
+// its own subdirectory, named streamsDirName/<streamID>. Nesting streams
+// one level down, rather than storing streamID directly under baseDir,
+// keeps any stream ID — including "all" itself — from ever colliding with
+// allDirName.
+const streamsDirName = "streams"
+
 // FilesStore is a file-backed [cqrs.EventStore] intended for tests and local
 // development. Each stream's events are stored as one JSON file per event
-// under a directory named after the stream ID, and a symlink to every event
-// is also kept under an "all" directory to support [FilesStore.LoadFromAll].
+// under its own directory (see streamDir), and a symlink to every event is
+// also kept under an "all" directory to support [FilesStore.LoadFromAll].
 // It is safe for concurrent use.
 type FilesStore struct {
 	baseDir   string
@@ -31,9 +42,12 @@ type FilesStore struct {
 }
 
 // NewFileStore creates a [FilesStore] rooted at dir, creating dir and its
-// "all" subdirectory if they do not already exist.
+// reserved subdirectories if they do not already exist.
 func NewFileStore(dir string) (*FilesStore, error) {
-	if err := os.MkdirAll(filepath.Join(dir, "all"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir, allDirName), 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(filepath.Join(dir, streamsDirName), 0o755); err != nil {
 		return nil, err
 	}
 	return &FilesStore{
@@ -43,7 +57,7 @@ func NewFileStore(dir string) (*FilesStore, error) {
 }
 
 func (f *FilesStore) streamDir(id string) string {
-	return filepath.Join(f.baseDir, id)
+	return filepath.Join(f.baseDir, streamsDirName, id)
 }
 
 // Save appends events to the stream they share, enforcing the concurrency
@@ -148,9 +162,9 @@ func (f *FilesStore) Save(ctx context.Context, events []cqrs.Envelope, revision 
 			return cqrs.AppendResult{StreamID: streamID, Successful: false}, err
 		}
 		// symlink to all/
-		all := filepath.Join(f.baseDir, "all", fmt.Sprintf("%010d-%s.json", events[i].GlobalVersion, events[i].Event.EventType()))
+		all := filepath.Join(f.baseDir, allDirName, fmt.Sprintf("%010d-%s.json", events[i].GlobalVersion, events[i].Event.EventType()))
 
-		rel, _ := filepath.Rel(filepath.Join(f.baseDir, "all"), path)
+		rel, _ := filepath.Rel(filepath.Join(f.baseDir, allDirName), path)
 
 		if err := os.Symlink(rel, all); err != nil {
 			return cqrs.AppendResult{
@@ -201,7 +215,7 @@ func (f *FilesStore) LoadStreamFrom(ctx context.Context, id string, version cqrs
 // [FilesStore.LoadStreamFrom], but against the global sequence rather than a
 // single stream.
 func (f *FilesStore) LoadFromAll(ctx context.Context, version cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
-	return f.loadFromDir(filepath.Join(f.baseDir, "all"), version)
+	return f.loadFromDir(filepath.Join(f.baseDir, allDirName), version)
 }
 
 // loadFromDir is the shared implementation behind LoadStream, LoadStreamFrom,

--- a/eventstore/file/filestorage_test.go
+++ b/eventstore/file/filestorage_test.go
@@ -1,0 +1,85 @@
+package file
+
+import (
+	"context"
+	"testing"
+
+	cqrs "github.com/terraskye/eventsourcing"
+)
+
+type allCollisionEvent struct {
+	Name string
+}
+
+func (e allCollisionEvent) AggregateID() string { return e.Name }
+func (e allCollisionEvent) EventType() string   { return "allCollisionEvent" }
+
+func init() {
+	cqrs.RegisterEventByType(func() cqrs.Event { return &allCollisionEvent{} })
+}
+
+func envelopeFor(streamID string, version uint64, name string) cqrs.Envelope {
+	return cqrs.Envelope{
+		StreamID: streamID,
+		Event:    allCollisionEvent{Name: name},
+		Version:  version,
+	}
+}
+
+// TestSave_StreamNamedAllCollidesWithGlobalDir is a regression test for
+// GitHub issue #38: streamDir(id) had no guard against the reserved "all"
+// directory name FilesStore uses for its global symlink fan-in, so a stream
+// literally named "all" read and wrote that same directory. Save with
+// NoStream{} against a brand-new stream "all" incorrectly failed with
+// "stream already exists" once any other stream had saved at least one
+// event, since the version count was polluted by every other stream's
+// symlinks.
+func TestSave_StreamNamedAllCollidesWithGlobalDir(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer store.Close()
+
+	// An unrelated stream writes one event; this also symlinks into all/.
+	if _, err := store.Save(ctx, []cqrs.Envelope{
+		envelopeFor("cart-1", 0, "unrelated"),
+	}, cqrs.NoStream{}); err != nil {
+		t.Fatalf("setup save to cart-1: %v", err)
+	}
+
+	// "all" has never been used as a real stream ID before. NoStream{} must
+	// succeed, exactly as it would for any other never-saved aggregate ID.
+	res, err := store.Save(ctx, []cqrs.Envelope{
+		envelopeFor("all", 0, "first-in-all"),
+	}, cqrs.NoStream{})
+	if err != nil {
+		t.Fatalf("Save(NoStream{}) for brand-new stream %q: expected success, got error: %v", "all", err)
+	}
+	if !res.Successful {
+		t.Fatalf("Save(NoStream{}) for brand-new stream %q: expected Successful=true", "all")
+	}
+
+	// The stream "all" should now be loadable on its own, containing only
+	// the one event just saved to it — not polluted by cart-1's event.
+	iter, err := store.LoadStream(ctx, "all")
+	if err != nil {
+		t.Fatalf("LoadStream(%q): %v", "all", err)
+	}
+	var envs []*cqrs.Envelope
+	for iter.Next(ctx) {
+		envs = append(envs, iter.Value())
+	}
+	if err := iter.Err(); err != nil {
+		t.Fatalf("iterate LoadStream(%q): %v", "all", err)
+	}
+	if len(envs) != 1 {
+		t.Fatalf("LoadStream(%q) = %d events, want 1", "all", len(envs))
+	}
+	if ev, ok := envs[0].Event.(*allCollisionEvent); !ok || ev.Name != "first-in-all" {
+		t.Fatalf("LoadStream(%q)[0].Event = %#v, want *allCollisionEvent{Name: \"first-in-all\"}", "all", envs[0].Event)
+	}
+}


### PR DESCRIPTION
## Summary
- `streamDir(id)` was a bare join of `baseDir` and `id`, with no guard against the `"all"` directory `FilesStore` reserves at its root for the global symlink fan-in `LoadFromAll` reads. A stream literally named `"all"` resolved to that same directory, so `Save`'s version count was polluted by every other stream's symlinks, permanently rejecting `NoStream{}` for a brand-new `"all"` stream with "stream already exists" — and a save that did get past that check would have written real event files into a directory `LoadFromAll` treats as pure symlinks.
- Nested per-stream directories one level down, under a new `"streams"` subdirectory, so no stream ID can ever collide with the top-level `"all"` directory. `FilesStore` is documented as intended for tests and local development, not durable long-term storage, so this on-disk layout change is acceptable.

Fixes #38

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass
- [x] Added `TestSave_StreamNamedAllCollidesWithGlobalDir` (adapted from the issue's repro, plus an extra check that the "all" stream loads back only its own event). Verified it actually catches the bug: reverted the fix, confirmed "stream already exists for stream all" exactly as the issue describes, then restored the fix and confirmed it passes