### PR TITLE
Fix FilesStore.Close not idempotent and Save-after-Close panicking

### DIFF
--- a/eventstore/file/filestorage.go
+++ b/eventstore/file/filestorage.go
@@ -37,6 +37,7 @@ const streamsDirName = "streams"
 type FilesStore struct {
 	baseDir   string
 	mu        sync.Mutex
+	closed    bool
 	bus       chan *cqrs.Envelope
 	globalSeq uint64
 }
@@ -88,6 +89,10 @@ func (f *FilesStore) Save(ctx context.Context, events []cqrs.Envelope, revision 
 
 	f.mu.Lock()
 	defer f.mu.Unlock()
+
+	if f.closed {
+		return cqrs.AppendResult{Successful: false, StreamID: streamID}, fmt.Errorf("save to stream %q: event store is closed", streamID)
+	}
 
 	os.MkdirAll(sdir, 0o755)
 
@@ -324,13 +329,17 @@ func (f *FilesStore) Events() <-chan *cqrs.Envelope {
 	return f.bus
 }
 
-// Close closes the channel returned by Events. After Close, the FilesStore
-// must not be used again.
-//
-// TODO: this is not idempotent, contrary to the cqrs.EventStore contract,
-// which asks implementations to make Close safe to call more than once — a
-// second call panics with "close of closed channel".
+// Close closes the channel returned by Events. After Close, Save returns an
+// error instead of appending. Calling Close more than once is a no-op.
 func (f *FilesStore) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.closed {
+		return nil
+	}
+	f.closed = true
+
 	close(f.bus)
 	return nil
 }

--- a/eventstore/file/filestorage_test.go
+++ b/eventstore/file/filestorage_test.go
@@ -83,3 +83,56 @@ func TestSave_StreamNamedAllCollidesWithGlobalDir(t *testing.T) {
 		t.Fatalf("LoadStream(%q)[0].Event = %#v, want *allCollisionEvent{Name: \"first-in-all\"}", "all", envs[0].Event)
 	}
 }
+
+// TestFileStoreClose_CalledTwice_Panics is a regression test for GitHub
+// issue #39: Close unconditionally called close(f.bus) with no guard, so
+// calling it a second time panicked with "close of closed channel",
+// contrary to the EventStore contract that Close must be idempotent.
+func TestFileStoreClose_CalledTwice_Panics(t *testing.T) {
+	store, err := NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("first Close: unexpected error: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("second Close panicked: %v (EventStore godoc requires Close to be idempotent)", r)
+		}
+	}()
+
+	if err := store.Close(); err != nil {
+		t.Errorf("second Close: unexpected error: %v", err)
+	}
+}
+
+// TestFileStoreSave_AfterClose_Panics is a regression test for GitHub issue
+// #39: Save's non-blocking send to f.bus only guarded against a full
+// channel, not a closed one, so any Save call after Close panicked with
+// "send on closed channel" instead of returning an error.
+func TestFileStoreSave_AfterClose_Panics(t *testing.T) {
+	store, err := NewFileStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: unexpected error: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Save after Close panicked: %v", r)
+		}
+	}()
+
+	_, err = store.Save(context.Background(), []cqrs.Envelope{
+		envelopeFor("order-1", 0, "after-close"),
+	}, cqrs.NoStream{})
+	if err == nil {
+		t.Error("expected an error saving to a closed store, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- `Close` unconditionally called `close(f.bus)`, so calling it a second time panicked with "close of closed channel".
- `Save`'s non-blocking send to `f.bus` only guarded against a full channel, not a closed one, so any `Save` call after `Close` panicked with "send on closed channel" instead of returning an error.
- Both contradict the `EventStore` contract that `Close` must be idempotent and the store must not be used afterward.
- Added a `closed` flag guarded by the existing mutex: `Close` sets it and is a no-op on a second call, and `Save` checks it up front and returns an error instead of writing anything (or reaching the send at all) once closed.

Fixes #39

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (173)
- [x] Added `TestFileStoreClose_CalledTwice_Panics` and `TestFileStoreSave_AfterClose_Panics` (adapted from the issue's repro). Verified both actually catch the bug: reverted the fix, reproduced both panics exactly as the issue describes, then restored the fix and confirmed both pass