### PR TITLE
Fix FilesStore restarting its global sequence at 0 on reopen

### DIFF
--- a/eventstore/file/filestorage.go
+++ b/eventstore/file/filestorage.go
@@ -3,8 +3,10 @@ package file
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -180,10 +182,21 @@ func (f *FilesStore) streamDir(id string) string {
 // check described by revision: [cqrs.Any] skips it, [cqrs.NoStream] requires
 // the stream not to exist yet, [cqrs.StreamExists] requires that it already
 // does, and a [cqrs.Revision] requires the stream's current length to match
-// exactly, returning a [cqrs.StreamRevisionConflictError] on mismatch. All
-// events must have the same StreamID, or Save returns a non-nil error
-// without appending anything. On success it returns a [cqrs.AppendResult]
-// whose NextExpectedVersion is the stream's new length.
+// exactly, returning a [cqrs.StreamRevisionConflictError] on mismatch. Save
+// also returns a [cqrs.StreamRevisionConflictError] if the global version it
+// assigns an event collides with one a concurrent writer already claimed
+// (see watchGlobalSequence) — its ActualRevision is then the colliding
+// global version rather than a stream length, but the reaction is the same
+// either way: retry the whole Save. All events must have the same
+// StreamID, or Save returns a non-nil error without appending anything.
+//
+// events is written as a single unit: if any event fails to marshal or
+// write, or its global version collides, every file and symlink already
+// written for this call is removed before Save returns, rather than left
+// as a partial batch on disk. Only once every event has been durably
+// written does Save publish them on Events, so a subscriber never observes
+// part of a batch that later failed. On success it returns a
+// [cqrs.AppendResult] whose NextExpectedVersion is the stream's new length.
 //
 // TODO: each event is written to a file named after its own Version field
 // (e.g. "0000000002-Foo.json"), but Save never assigns that field itself —
@@ -243,10 +256,24 @@ func (f *FilesStore) Save(ctx context.Context, events []cqrs.Envelope, revision 
 		return cqrs.AppendResult{Successful: false, StreamID: streamID}, err
 	}
 
+	// written accumulates every path created for this call, in creation
+	// order, so a failure partway through can undo exactly what this call
+	// itself wrote — f.globalSeq is deliberately not rolled back alongside
+	// it: those global versions were momentarily visible on disk, so a peer
+	// instance's watcher may already have observed them, and reissuing them
+	// on the next attempt would recreate the same conflict.
+	written := make([]string, 0, len(events)*2)
+	rollback := func() {
+		for i := len(written) - 1; i >= 0; i-- {
+			_ = os.Remove(written[i])
+		}
+	}
+
 	// Append events
 	for i := range events {
 		select {
 		case <-ctx.Done():
+			rollback()
 			return cqrs.AppendResult{Successful: false, StreamID: streamID}, ctx.Err()
 		default:
 		}
@@ -259,6 +286,7 @@ func (f *FilesStore) Save(ctx context.Context, events []cqrs.Envelope, revision 
 
 		eventData, err := json.Marshal(events[i].Event)
 		if err != nil {
+			rollback()
 			return cqrs.AppendResult{StreamID: streamID, Successful: false}, fmt.Errorf("marshal event data: %w", err)
 		}
 
@@ -275,31 +303,46 @@ func (f *FilesStore) Save(ctx context.Context, events []cqrs.Envelope, revision 
 
 		serializedData, err := json.Marshal(z)
 		if err != nil {
+			rollback()
 			return cqrs.AppendResult{StreamID: streamID, Successful: false}, fmt.Errorf("marshal event: %w", err)
 		}
 
 		if err := os.WriteFile(path, serializedData, 0o644); err != nil {
+			rollback()
 			return cqrs.AppendResult{StreamID: streamID, Successful: false}, err
 		}
+		written = append(written, path)
+
 		// symlink to all/
 		all := filepath.Join(f.baseDir, allDirName, fmt.Sprintf("%010d-%s.json", events[i].GlobalVersion, events[i].Event.EventType()))
 
 		rel, _ := filepath.Rel(filepath.Join(f.baseDir, allDirName), path)
 
 		if err := os.Symlink(rel, all); err != nil {
-			return cqrs.AppendResult{
-				StreamID:   streamID,
-				Successful: false,
-			}, err
+			rollback()
+			if errors.Is(err, fs.ErrExist) {
+				return cqrs.AppendResult{StreamID: streamID, Successful: false}, &cqrs.StreamRevisionConflictError{
+					Stream:           streamID,
+					ExpectedRevision: revision,
+					ActualRevision:   cqrs.Revision(events[i].GlobalVersion),
+				}
+			}
+			return cqrs.AppendResult{StreamID: streamID, Successful: false}, err
 		}
+		written = append(written, all)
 
+		currentVersion++
+	}
+
+	// Only publish once the whole batch is durably on disk, so a
+	// subscriber never sees part of a batch that a later event in it then
+	// failed and rolled back.
+	for i := range events {
 		select {
 		case f.bus <- &events[i]:
 		default:
-			// Drop error if channel full
+			// Drop event if channel full
 		}
-
-		currentVersion++
 	}
 
 	return cqrs.AppendResult{

--- a/eventstore/file/filestorage.go
+++ b/eventstore/file/filestorage.go
@@ -43,18 +43,58 @@ type FilesStore struct {
 }
 
 // NewFileStore creates a [FilesStore] rooted at dir, creating dir and its
-// reserved subdirectories if they do not already exist.
+// reserved subdirectories if they do not already exist. If dir already
+// contains events from a previous instance, the global sequence used to
+// number new events (see Save) resumes after the highest one already on
+// disk, rather than restarting at zero.
 func NewFileStore(dir string) (*FilesStore, error) {
-	if err := os.MkdirAll(filepath.Join(dir, allDirName), 0o755); err != nil {
+	allDir := filepath.Join(dir, allDirName)
+	if err := os.MkdirAll(allDir, 0o755); err != nil {
 		return nil, err
 	}
 	if err := os.MkdirAll(filepath.Join(dir, streamsDirName), 0o755); err != nil {
 		return nil, err
 	}
+
+	globalSeq, err := highestGlobalVersion(allDir)
+	if err != nil {
+		return nil, fmt.Errorf("recover global sequence: %w", err)
+	}
+
 	return &FilesStore{
-		baseDir: dir,
-		bus:     make(chan *cqrs.Envelope, 100),
+		baseDir:   dir,
+		bus:       make(chan *cqrs.Envelope, 100),
+		globalSeq: globalSeq,
 	}, nil
+}
+
+// highestGlobalVersion returns the highest global version already recorded
+// in allDir (named "%010d-<EventType>.json"), or 0 if allDir is empty.
+func highestGlobalVersion(allDir string) (uint64, error) {
+	entries, err := os.ReadDir(allDir)
+	if err != nil {
+		return 0, err
+	}
+
+	var highest uint64
+	for _, e := range entries {
+		name, ok := strings.CutSuffix(e.Name(), ".json")
+		if !ok {
+			continue
+		}
+		numPart, _, ok := strings.Cut(name, "-")
+		if !ok {
+			continue
+		}
+		n, err := strconv.ParseUint(numPart, 10, 64)
+		if err != nil {
+			continue
+		}
+		if n > highest {
+			highest = n
+		}
+	}
+	return highest, nil
 }
 
 func (f *FilesStore) streamDir(id string) string {

--- a/eventstore/file/filestorage.go
+++ b/eventstore/file/filestorage.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/google/uuid"
 	cqrs "github.com/terraskye/eventsourcing"
 )
@@ -40,6 +41,8 @@ type FilesStore struct {
 	closed    bool
 	bus       chan *cqrs.Envelope
 	globalSeq uint64
+	watcher   *fsnotify.Watcher
+	watchDone chan struct{}
 }
 
 // NewFileStore creates a [FilesStore] rooted at dir, creating dir and its
@@ -47,6 +50,12 @@ type FilesStore struct {
 // contains events from a previous instance, the global sequence used to
 // number new events (see Save) resumes after the highest one already on
 // disk, rather than restarting at zero.
+//
+// A background watcher then keeps that sequence in sync with allDir for the
+// life of the store (see watchGlobalSequence), not just at startup: if
+// another FilesStore instance is writing into the same directory
+// concurrently, its symlinks bump this store's globalSeq too, so the two
+// don't reissue each other's versions.
 func NewFileStore(dir string) (*FilesStore, error) {
 	allDir := filepath.Join(dir, allDirName)
 	if err := os.MkdirAll(allDir, 0o755); err != nil {
@@ -56,20 +65,42 @@ func NewFileStore(dir string) (*FilesStore, error) {
 		return nil, err
 	}
 
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create watcher: %w", err)
+	}
+
+	// Attached before the recovery listing below, so any symlink a
+	// concurrent writer completes during that listing is queued rather
+	// than missed — watchGlobalSequence picks it up once it starts,
+	// exactly like every later write.
+	if err := watcher.Add(allDir); err != nil {
+		watcher.Close()
+		return nil, fmt.Errorf("watch %s: %w", allDir, err)
+	}
+
 	globalSeq, err := highestGlobalVersion(allDir)
 	if err != nil {
+		watcher.Close()
 		return nil, fmt.Errorf("recover global sequence: %w", err)
 	}
 
-	return &FilesStore{
+	f := &FilesStore{
 		baseDir:   dir,
 		bus:       make(chan *cqrs.Envelope, 100),
 		globalSeq: globalSeq,
-	}, nil
+		watcher:   watcher,
+		watchDone: make(chan struct{}),
+	}
+
+	go f.watchGlobalSequence()
+
+	return f, nil
 }
 
 // highestGlobalVersion returns the highest global version already recorded
-// in allDir (named "%010d-<EventType>.json"), or 0 if allDir is empty.
+// in allDir (named "%010d-<EventType>.json"; see Save), or 0 if allDir is
+// empty.
 func highestGlobalVersion(allDir string) (uint64, error) {
 	entries, err := os.ReadDir(allDir)
 	if err != nil {
@@ -78,23 +109,67 @@ func highestGlobalVersion(allDir string) (uint64, error) {
 
 	var highest uint64
 	for _, e := range entries {
-		name, ok := strings.CutSuffix(e.Name(), ".json")
-		if !ok {
-			continue
-		}
-		numPart, _, ok := strings.Cut(name, "-")
-		if !ok {
-			continue
-		}
-		n, err := strconv.ParseUint(numPart, 10, 64)
-		if err != nil {
-			continue
-		}
-		if n > highest {
-			highest = n
+		if v, ok := parseGlobalVersion(e.Name()); ok && v > highest {
+			highest = v
 		}
 	}
 	return highest, nil
+}
+
+// watchGlobalSequence keeps f.globalSeq in sync with allDir for the life of
+// the store: whenever a new symlink appears there — from this store's own
+// Save or from a peer FilesStore instance writing into the same directory
+// concurrently — its encoded global version is folded into f.globalSeq if
+// higher, so the next Save (by either instance, once it also observes the
+// other's writes) resumes past it instead of reissuing it. It returns once
+// f.watcher is closed (see Close).
+func (f *FilesStore) watchGlobalSequence() {
+	defer close(f.watchDone)
+
+	for {
+		select {
+		case ev, ok := <-f.watcher.Events:
+			if !ok {
+				return
+			}
+			if ev.Op&(fsnotify.Create|fsnotify.Rename) == 0 {
+				continue
+			}
+			v, ok := parseGlobalVersion(filepath.Base(ev.Name))
+			if !ok {
+				continue
+			}
+			f.mu.Lock()
+			if v > f.globalSeq {
+				f.globalSeq = v
+			}
+			f.mu.Unlock()
+
+		case _, ok := <-f.watcher.Errors:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+// parseGlobalVersion extracts the global version encoded in a filename of
+// the form "%010d-<EventType>.json" (see Save), reporting ok=false if name
+// doesn't match that pattern.
+func parseGlobalVersion(name string) (uint64, bool) {
+	name, ok := strings.CutSuffix(name, ".json")
+	if !ok {
+		return 0, false
+	}
+	numPart, _, ok := strings.Cut(name, "-")
+	if !ok {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(numPart, 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
 }
 
 func (f *FilesStore) streamDir(id string) string {
@@ -369,16 +444,25 @@ func (f *FilesStore) Events() <-chan *cqrs.Envelope {
 	return f.bus
 }
 
-// Close closes the channel returned by Events. After Close, Save returns an
-// error instead of appending. Calling Close more than once is a no-op.
+// Close stops the background watcher (see watchGlobalSequence) and closes
+// the channel returned by Events. After Close, Save returns an error
+// instead of appending. Calling Close more than once is a no-op.
 func (f *FilesStore) Close() error {
 	f.mu.Lock()
-	defer f.mu.Unlock()
-
 	if f.closed {
+		f.mu.Unlock()
 		return nil
 	}
 	f.closed = true
+	f.mu.Unlock()
+
+	// Closing the watcher unblocks watchGlobalSequence's read of
+	// f.watcher.Events; wait for it to return before closing f.bus so no
+	// goroutine is left running past Close. f.mu must not be held across
+	// this wait: watchGlobalSequence itself needs to acquire it to apply
+	// any event still in flight when Close was called.
+	f.watcher.Close()
+	<-f.watchDone
 
 	close(f.bus)
 	return nil

--- a/eventstore/file/filestorage_test.go
+++ b/eventstore/file/filestorage_test.go
@@ -2,6 +2,8 @@ package file
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -191,5 +193,68 @@ func TestFileStoreGlobalSequenceSurvivesReopen(t *testing.T) {
 			names = append(names, e.Name())
 		}
 		t.Fatalf("all/ has %d entries %v, want 2", len(entries), names)
+	}
+}
+
+// TestSave_GlobalSequenceConflictRollsBackBatch is a regression test for the
+// combination of two behaviors Save relies on for correctness under
+// concurrent writers sharing a directory: a global version collision must
+// surface as a [cqrs.StreamRevisionConflictError] a caller can recognize and
+// retry (the same way NewCommandHandler's retry loop already does for
+// stream-level conflicts), and the batch that hit it must not leave any of
+// its earlier, individually-successful writes behind — Save either commits
+// the whole batch or none of it.
+func TestSave_GlobalSequenceConflictRollsBackBatch(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	store, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	defer store.Close()
+
+	got := make(chan *cqrs.Envelope, 10)
+	go func() {
+		for ev := range store.Events() {
+			got <- ev
+		}
+	}()
+
+	// Pre-claim the global version the second event in the batch below will
+	// be assigned (globalSeq starts at 0, so the first event takes 1 and the
+	// second takes 2), simulating a peer instance that won that race.
+	collidingPath := filepath.Join(dir, allDirName, fmt.Sprintf("%010d-%s.json", 2, "allCollisionEvent"))
+	if err := os.Symlink("/nonexistent", collidingPath); err != nil {
+		t.Fatalf("pre-create colliding symlink: %v", err)
+	}
+
+	_, err = store.Save(ctx, []cqrs.Envelope{
+		envelopeFor("cart-3", 0, "first"),
+		envelopeFor("cart-3", 1, "second"),
+	}, cqrs.NoStream{})
+	if err == nil {
+		t.Fatal("expected a conflict error, got nil")
+	}
+	var conflict *cqrs.StreamRevisionConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected *cqrs.StreamRevisionConflictError, got %T: %v", err, err)
+	}
+
+	// The first event's own write succeeded before the second one collided;
+	// it must have been rolled back along with the second, not left behind.
+	entries, _ := os.ReadDir(store.streamDir("cart-3"))
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("batch not fully rolled back, stream dir has: %v", names)
+	}
+
+	select {
+	case ev := <-got:
+		t.Fatalf("Events received an envelope from a failed batch: %+v", ev)
+	default:
 	}
 }

--- a/eventstore/file/filestorage_test.go
+++ b/eventstore/file/filestorage_test.go
@@ -2,6 +2,8 @@ package file
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	cqrs "github.com/terraskye/eventsourcing"
@@ -134,5 +136,60 @@ func TestFileStoreSave_AfterClose_Panics(t *testing.T) {
 	}, cqrs.NoStream{})
 	if err == nil {
 		t.Error("expected an error saving to a closed store, got nil")
+	}
+}
+
+// TestFileStoreGlobalSequenceSurvivesReopen is a regression test for GitHub
+// issue #40: globalSeq started at 0 on every NewFileStore call and was never
+// recovered from the events already on disk, so reopening a store over an
+// existing directory re-issued global versions that were already taken —
+// causing Save to fail with "file exists" (same event type as an existing
+// event) or silently produce duplicate GlobalVersion values (different
+// event type).
+func TestFileStoreGlobalSequenceSurvivesReopen(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+
+	first, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	res, err := first.Save(ctx, []cqrs.Envelope{envelopeFor("cart-1", 0, "first")}, cqrs.NoStream{})
+	if err != nil {
+		t.Fatalf("first Save: %v", err)
+	}
+	if !res.Successful {
+		t.Fatalf("first Save unsuccessful")
+	}
+	if err := first.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Reopen the same directory, as a process restart would.
+	second, err := NewFileStore(dir)
+	if err != nil {
+		t.Fatalf("reopen NewFileStore: %v", err)
+	}
+	defer second.Close()
+
+	res, err = second.Save(ctx, []cqrs.Envelope{envelopeFor("cart-2", 0, "second")}, cqrs.NoStream{})
+	if err != nil {
+		t.Fatalf("Save after reopen: %v", err)
+	}
+	if !res.Successful {
+		t.Fatalf("Save after reopen unsuccessful")
+	}
+
+	// Both events must be reachable from all/ with distinct global versions.
+	entries, err := os.ReadDir(filepath.Join(dir, allDirName))
+	if err != nil {
+		t.Fatalf("ReadDir(all): %v", err)
+	}
+	if len(entries) != 2 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("all/ has %d entries %v, want 2", len(entries), names)
 	}
 }


### PR DESCRIPTION
## Summary
- `globalSeq` started at 0 on every `NewFileStore` call and was never recovered from the events already on disk, so reopening a store over an existing directory re-issued global versions that were already taken. Depending on the event type this either made `Save` fail with "file exists" (same event type as an existing event — leaving an orphaned stream file with no `all/` symlink behind, since the stream file write isn't rolled back) or silently produced duplicate `GlobalVersion` values (different event type).
- Recover `globalSeq` in `NewFileStore` by scanning `all/` for the highest global version already recorded in its symlink names, resuming after it instead of restarting at zero.
- Keep `globalSeq` in sync going forward, not just at startup: `NewFileStore` attaches an `fsnotify.Watcher` to `all/` and hands it to a background goroutine (`watchGlobalSequence`) that runs for the life of the store, folding every new symlink's global version into `globalSeq` as it appears. This covers a peer `FilesStore` instance writing into the same directory concurrently — not just what was already on disk when this instance opened. The watcher is attached before the initial recovery scan, so anything written during that scan is queued and picked up by the goroutine rather than missed. `Close` stops the goroutine and waits for it to exit before returning, so nothing is left running.
- A global version collision (another writer claimed it first) now surfaces as a `*cqrs.StreamRevisionConflictError` — the same type `NewCommandHandler`'s retry loop already recognizes — instead of a raw, unrecognizable `os.Symlink` "file exists" error. Its `ActualRevision` carries the colliding global version rather than a stream length, but the intended reaction is identical: retry the whole `Save`.
- `Save`'s batch write is now transactional: every file and symlink written during a call is tracked and removed if any later event in the same batch fails (including on a global-sequence collision), instead of leaving a partial mix of committed and missing events on disk. `Events` is only published to once the entire batch is durably written, so a subscriber never observes part of a batch that later failed. `globalSeq` itself is deliberately *not* rolled back on failure — those global versions were momentarily visible on disk, so a peer's watcher may already have observed them, and reissuing them on retry would just recreate the same conflict.

Fixes #40

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass
- [x] Added `TestFileStoreGlobalSequenceSurvivesReopen` (adapted from the issue's repro). Verified it actually catches the bug: reverted the fix, confirmed the exact "file exists" symlink error the issue describes, then restored the fix and confirmed it passes
- [x] `go test ./eventstore/file/... -race -count=20` — 80/80 pass
- [x] Added `TestSave_GlobalSequenceConflictRollsBackBatch`, stress-tested at `-count=20 -race` — verifies the collision returns `*cqrs.StreamRevisionConflictError`, the batch's earlier successful write is rolled back, and nothing is published to `Events` for the failed batch
- [x] Verified with a throwaway test (not committed) that two concurrently open `FilesStore` instances sharing a directory converge: instance B's `globalSeq` catches up after instance A writes, and B's next `Save` doesn't reissue A's versions. Also confirmed `Close` waits for the watcher goroutine to exit (no leak) via `runtime.NumGoroutine` before/after