### PR TITLE
Fix LoadStreamFrom failing with a raw OS error for a never-saved stream

### DIFF
--- a/eventstore/file/filestorage.go
+++ b/eventstore/file/filestorage.go
@@ -386,10 +386,17 @@ func (f *FilesStore) LoadFromAll(ctx context.Context, version cqrs.StreamState) 
 // described by from, and returns a lazy iterator over the decoded events in
 // filename order.
 func (f *FilesStore) loadFromDir(dir string, from cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
+	// A stream's directory is only created lazily, on its first successful
+	// Save, so a never-saved stream (a perfectly normal thing to load, e.g.
+	// via Any{} or NoStream{} for a brand-new aggregate) has no directory at
+	// all yet — that's an empty stream, not an error, and the StreamState
+	// switch below decides whether an empty stream is acceptable.
 	files, err := os.ReadDir(dir)
 	if err != nil {
-		//TODO handle errors.
-		return nil, err
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+		files = nil
 	}
 
 	var offset uint64

--- a/eventstore/file/filestorage_test.go
+++ b/eventstore/file/filestorage_test.go
@@ -258,3 +258,65 @@ func TestSave_GlobalSequenceConflictRollsBackBatch(t *testing.T) {
 	default:
 	}
 }
+
+// TestLoadStreamFrom_NeverCreatedStream is a regression test for GitHub
+// issue #41: loadFromDir called os.ReadDir on a stream's directory before
+// looking at the requested StreamState. A stream's directory is only
+// created lazily inside Save, on its first successful write, so loading a
+// brand-new aggregate ID failed with a raw *fs.PathError for every
+// StreamState, including Any{} and NoStream{}, which both document success
+// in this exact situation.
+func TestLoadStreamFrom_NeverCreatedStream(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Any_should_yield_empty_iterator", func(t *testing.T) {
+		dir := t.TempDir()
+		store, err := NewFileStore(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+
+		iter, err := store.LoadStreamFrom(ctx, "brand-new-aggregate", cqrs.Any{})
+		if err != nil {
+			t.Fatalf("Any{} on a never-saved stream: expected no error, got: %v", err)
+		}
+		if iter.Next(ctx) {
+			t.Fatalf("expected an empty iterator for a never-saved stream")
+		}
+	})
+
+	t.Run("NoStream_should_yield_empty_iterator", func(t *testing.T) {
+		dir := t.TempDir()
+		store, err := NewFileStore(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+
+		iter, err := store.LoadStreamFrom(ctx, "brand-new-aggregate", cqrs.NoStream{})
+		if err != nil {
+			t.Fatalf("NoStream{} on a never-saved stream: expected no error (stream genuinely does not exist), got: %v", err)
+		}
+		if iter.Next(ctx) {
+			t.Fatalf("expected an empty iterator for a never-saved stream")
+		}
+	})
+
+	t.Run("StreamExists_should_wrap_ErrStreamNotFound", func(t *testing.T) {
+		dir := t.TempDir()
+		store, err := NewFileStore(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer store.Close()
+
+		_, err = store.LoadStreamFrom(ctx, "brand-new-aggregate", cqrs.StreamExists{})
+		if err == nil {
+			t.Fatalf("expected an error for StreamExists{} on a never-saved stream")
+		}
+		if !errors.Is(err, cqrs.ErrStreamNotFound) {
+			t.Fatalf("expected err to wrap cqrs.ErrStreamNotFound, got: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- `loadFromDir` called `os.ReadDir` on a stream's directory before looking at the requested `StreamState`. A stream's directory is only created lazily inside `Save`, on its first successful write, so loading a brand-new aggregate ID failed with a raw `*fs.PathError` for every `StreamState`, including `Any{}` and `NoStream{}`, which both document success in this exact situation, and `StreamExists{}`, whose documented `ErrStreamNotFound` wrapping was unreachable as a result.
- This broke `NewCommandHandler`'s own documented default (`WithStreamState(Any{})`) backed by this store: it can never create a new aggregate's very first event, since the load in its handle loop always fails first.
- Treat `os.ErrNotExist` from `os.ReadDir` as an empty stream (no directory yet is exactly what a never-saved stream looks like) instead of propagating it, and let the existing `StreamState` switch decide from there, same as it already does for a directory that exists but happens to be empty.

Fixes #41

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (175)
- [x] Added `TestLoadStreamFrom_NeverCreatedStream` (adapted from the issue's repro, 3 subtests: `Any{}`, `NoStream{}`, `StreamExists{}`). Verified they actually catch the bug: reverted the fix, confirmed all 3 fail with the raw OS path error exactly as the issue describes, then restored the fix and confirmed all pass