### PR TITLE
Fix loadFromDir rejecting Revision(N) at the stream/global-log head

### DIFF
--- a/eventstore/file/filestorage.go
+++ b/eventstore/file/filestorage.go
@@ -357,7 +357,7 @@ func (f *FilesStore) Save(ctx context.Context, events []cqrs.Envelope, revision 
 // identified by id, in the order they were appended. It returns a non-nil
 // error if the stream does not exist.
 func (f *FilesStore) LoadStream(ctx context.Context, id string) (*cqrs.Iterator[*cqrs.Envelope], error) {
-	return f.loadFromDir(f.streamDir(id), cqrs.StreamExists{})
+	return f.loadFromDir(f.streamDir(id), cqrs.StreamExists{}, false)
 }
 
 // LoadStreamFrom returns a lazy iterator over the events in the stream
@@ -369,7 +369,7 @@ func (f *FilesStore) LoadStream(ctx context.Context, id string) (*cqrs.Iterator[
 // beginning of the stream. It also returns a non-nil error if the requested
 // revision is beyond the stream's current length.
 func (f *FilesStore) LoadStreamFrom(ctx context.Context, id string, version cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
-	return f.loadFromDir(f.streamDir(id), version)
+	return f.loadFromDir(f.streamDir(id), version, false)
 }
 
 // LoadFromAll returns a lazy iterator over every event saved across all
@@ -378,14 +378,21 @@ func (f *FilesStore) LoadStreamFrom(ctx context.Context, id string, version cqrs
 // [FilesStore.LoadStreamFrom], but against the global sequence rather than a
 // single stream.
 func (f *FilesStore) LoadFromAll(ctx context.Context, version cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
-	return f.loadFromDir(filepath.Join(f.baseDir, allDirName), version)
+	return f.loadFromDir(filepath.Join(f.baseDir, allDirName), version, true)
 }
 
 // loadFromDir is the shared implementation behind LoadStream, LoadStreamFrom,
 // and LoadFromAll: it lists dir, applies the precondition or starting offset
 // described by from, and returns a lazy iterator over the decoded events in
 // filename order.
-func (f *FilesStore) loadFromDir(dir string, from cqrs.StreamState) (*cqrs.Iterator[*cqrs.Envelope], error) {
+//
+// oneIndexed distinguishes the two numbering conventions files in dir are
+// named by: a stream directory's files are named after Envelope.Version,
+// which starts at 0, while the "all" directory's files are named after
+// Envelope.GlobalVersion, which starts at 1 — so a Revision(N) start
+// position (meaning "N events already seen") must skip versions < N in the
+// 0-indexed case, but versions <= N in the 1-indexed one.
+func (f *FilesStore) loadFromDir(dir string, from cqrs.StreamState, oneIndexed bool) (*cqrs.Iterator[*cqrs.Envelope], error) {
 	// A stream's directory is only created lazily, on its first successful
 	// Save, so a never-saved stream (a perfectly normal thing to load, e.g.
 	// via Any{} or NoStream{} for a brand-new aggregate) has no directory at
@@ -417,7 +424,12 @@ func (f *FilesStore) loadFromDir(dir string, from cqrs.StreamState) (*cqrs.Itera
 			)
 		}
 	case cqrs.Revision:
-		if int(from.ToRawInt64()) >= len(files) {
+		// A start index equal to the stream's length is valid — it means
+		// "give me anything newer than what I've already seen", the same
+		// half-open convention Save itself relies on when it accepts
+		// Revision(currentVersion) as the expected revision to append
+		// against. Only a position beyond the stream's length is invalid.
+		if int(from.ToRawInt64()) > len(files) {
 			return nil, fmt.Errorf(
 				"load stream %q: requested %d but stream has %d: %w",
 				dir, from, len(files), cqrs.ErrInvalidRevision,
@@ -441,7 +453,11 @@ func (f *FilesStore) loadFromDir(dir string, from cqrs.StreamState) (*cqrs.Itera
 				continue
 			}
 			ver, _ := strconv.ParseUint(parts[0], 10, 64)
-			if ver < offset {
+			if oneIndexed {
+				if ver <= offset {
+					continue
+				}
+			} else if ver < offset {
 				continue
 			}
 

--- a/eventstore/file/filestorage_test.go
+++ b/eventstore/file/filestorage_test.go
@@ -320,3 +320,118 @@ func TestLoadStreamFrom_NeverCreatedStream(t *testing.T) {
 		}
 	})
 }
+
+// TestLoadStreamFrom_RevisionAtStreamHead is a regression test for GitHub
+// issue #42: loadFromDir's Revision guard used >= where a start index needs
+// >, so asking for the revision a stream is currently at — "I am caught up,
+// give me anything newer" — returned ErrInvalidRevision instead of an empty
+// iterator. Revision(0) against an empty-but-existing stream made it
+// impossible to create a new aggregate through NewCommandHandler configured
+// with WithStreamState(Revision(0)).
+func TestLoadStreamFrom_RevisionAtStreamHead(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		eventCount int
+	}{
+		{name: "fresh stream, revision 0", eventCount: 0},
+		{name: "one event, revision 1", eventCount: 1},
+		{name: "three events, revision 3", eventCount: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, err := NewFileStore(dir)
+			if err != nil {
+				t.Fatalf("NewFileStore: %v", err)
+			}
+			defer store.Close()
+
+			if tt.eventCount > 0 {
+				events := make([]cqrs.Envelope, tt.eventCount)
+				for i := range events {
+					events[i] = envelopeFor("order-1", uint64(i), "item")
+				}
+				if _, err := store.Save(ctx, events, cqrs.Any{}); err != nil {
+					t.Fatalf("setup save: %v", err)
+				}
+			} else {
+				// Isolate the off-by-one from the unrelated "stream directory was
+				// never created" case: create the (empty) stream directory directly.
+				if err := os.MkdirAll(store.streamDir("order-1"), 0o755); err != nil {
+					t.Fatalf("setup mkdir: %v", err)
+				}
+			}
+
+			iter, err := store.LoadStreamFrom(ctx, "order-1", cqrs.Revision(tt.eventCount))
+			if err != nil {
+				t.Fatalf("LoadStreamFrom(Revision(%d)) on a stream with %d events: "+
+					"expected an empty iterator, got error: %v", tt.eventCount, tt.eventCount, err)
+			}
+
+			count := 0
+			for iter.Next(ctx) {
+				count++
+			}
+			if err := iter.Err(); err != nil {
+				t.Fatalf("iterator error: %v", err)
+			}
+			if count != 0 {
+				t.Errorf("expected 0 events past the head, got %d", count)
+			}
+		})
+	}
+}
+
+// TestLoadFromAll_RevisionAtHead is the LoadFromAll counterpart of
+// TestLoadStreamFrom_RevisionAtStreamHead: the same off-by-one guard backs
+// both, so it affects global-log reads too.
+func TestLoadFromAll_RevisionAtHead(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		eventCount int
+	}{
+		{name: "empty store, position 0", eventCount: 0},
+		{name: "two events, position 2", eventCount: 2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			store, err := NewFileStore(dir)
+			if err != nil {
+				t.Fatalf("NewFileStore: %v", err)
+			}
+			defer store.Close()
+
+			for i := 0; i < tt.eventCount; i++ {
+				if _, err := store.Save(ctx, []cqrs.Envelope{
+					envelopeFor("order-1", uint64(i), "item"),
+				}, cqrs.Any{}); err != nil {
+					t.Fatalf("setup save: %v", err)
+				}
+			}
+
+			iter, err := store.LoadFromAll(ctx, cqrs.Revision(tt.eventCount))
+			if err != nil {
+				t.Fatalf("LoadFromAll(Revision(%d)) with %d events stored: "+
+					"expected an empty iterator, got error: %v", tt.eventCount, tt.eventCount, err)
+			}
+
+			count := 0
+			for iter.Next(ctx) {
+				count++
+			}
+			if err := iter.Err(); err != nil {
+				t.Fatalf("iterator error: %v", err)
+			}
+			if count != 0 {
+				t.Errorf("expected 0 events past the head, got %d", count)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- The `Revision` guard used `>=` where a start index needs `>`, so asking for the revision a stream (or the global log) is currently at — the "I am caught up, give me anything newer" request — returned `ErrInvalidRevision` instead of an empty iterator. `Revision(0)` against an empty-but-existing stream made it impossible to create a new aggregate through `NewCommandHandler` configured with `WithStreamState(Revision(0))`.
- Loosening that guard exposed a second, previously-unreachable bug in the same function: `LoadFromAll`'s iteration skipped entries with `ver < offset`, which is correct for a stream directory (files named after `Envelope.Version`, 0-indexed) but wrong for the `"all"` directory (files named after `Envelope.GlobalVersion`, 1-indexed) — `Revision(N)` there still included the Nth, already-seen event. The stricter guard had always rejected this exact boundary case outright, so the bug never had a chance to surface. Added an explicit `oneIndexed` parameter to `loadFromDir` so each caller's own numbering convention is applied correctly.

Fixes #42

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (178, up from 175)
- [x] Added `TestLoadStreamFrom_RevisionAtStreamHead` and `TestLoadFromAll_RevisionAtHead` (adapted from the issue's repro). Verified they actually catch both bugs: reverted the fix, confirmed all 5 subtests fail exactly as the issue describes, then restored the fix and confirmed all 7 pass (the extra 2 subtests cover the second bug found while implementing this one)