### PR TITLE
Fix WithFilterEvents blocking every event on an empty filter list

### DIFF
--- a/eventbus/kurrentdb/eventbus.go
+++ b/eventbus/kurrentdb/eventbus.go
@@ -377,18 +377,24 @@ func WithStartAt(revision uint64) cqrs.SubscriberOption {
 
 // WithFilterEvents returns a [cqrs.SubscriberOption] that configures a
 // newly created persistent subscription's server-side filter to include
-// only events whose KurrentDB event type is one of filteredEvents. It has
-// no effect on a subscription that already exists in KurrentDB. Since a
-// persistent subscription has a single filter, combine all desired names
-// into one call rather than calling this more than once: applying it
-// together with WithFilterStream, or applying either more than once, means
-// only the last one applied takes effect. It panics if applied to a bus
-// other than this package's [EventBus].
+// only events whose KurrentDB event type is one of filteredEvents. An empty
+// or nil filteredEvents leaves the subscription unfiltered — matching every
+// event type — same as the memory, file, and postgres EventBus
+// implementations' own empty-filter conventions. It has no effect on a
+// subscription that already exists in KurrentDB. Since a persistent
+// subscription has a single filter, combine all desired names into one call
+// rather than calling this more than once: applying it together with
+// WithFilterStream, or applying either more than once, means only the last
+// one applied takes effect. It panics if applied to a bus other than this
+// package's [EventBus].
 func WithFilterEvents(filteredEvents []string) cqrs.SubscriberOption {
 	return func(cfg any) {
 		opts, ok := cfg.(*kurrentdb.PersistentAllSubscriptionOptions)
 		if !ok {
 			panic(fmt.Sprintf("WithFilterEvents: expected *SubscribeToAllOptions, got %T", cfg))
+		}
+		if len(filteredEvents) == 0 {
+			return
 		}
 		opts.Filter = &kurrentdb.SubscriptionFilter{
 			Type:  kurrentdb.EventFilterType,

--- a/eventbus/kurrentdb/with_filter_events_empty_test.go
+++ b/eventbus/kurrentdb/with_filter_events_empty_test.go
@@ -1,0 +1,40 @@
+package kurrentdb
+
+import (
+	"regexp"
+	"testing"
+
+	kdb "github.com/kurrent-io/KurrentDB-Client-Go/kurrentdb"
+)
+
+// TestWithFilterEvents_EmptySliceMeansCatchAll is a regression test for
+// GitHub issue #46: WithFilterEvents built the server-side filter regex as
+// fmt.Sprintf("^(%s)$", strings.Join(filteredEvents, "|")) with no special
+// case for an empty list, producing the literal regex "^()$" — which
+// matches only the empty string, so a subscriber configured with a nil or
+// empty filter never received a single event, silently. Every other
+// EventBus implementation in this module treats an empty filter as "no
+// filtering — deliver everything".
+func TestWithFilterEvents_EmptySliceMeansCatchAll(t *testing.T) {
+	opts := &kdb.PersistentAllSubscriptionOptions{}
+	WithFilterEvents(nil)(opts)
+
+	if opts.Filter == nil {
+		// No filter at all is also a valid way to mean "catch-all" — the
+		// fix takes this path, leaving opts.Filter unset.
+		return
+	}
+
+	re, err := regexp.Compile(opts.Filter.Regex)
+	if err != nil {
+		t.Fatalf("built an invalid regex %q: %v", opts.Filter.Regex, err)
+	}
+
+	for _, eventType := range []string{"OrderCreated", "ItemAdded", "leakEvent"} {
+		if !re.MatchString(eventType) {
+			t.Errorf("empty filter should match every event type (catch-all, matching the "+
+				"memory/file/postgres EventBus convention), but regex %q does not match %q",
+				opts.Filter.Regex, eventType)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `WithFilterEvents` built the server-side filter regex as `fmt.Sprintf("^(%s)$", strings.Join(filteredEvents, " |"))` with no special case for an empty list, producing the literal regex `^()$` — which matches only the empty string, so a subscriber configured with a nil or empty filter never received a single event, silently, with no error anywhere. Every other `EventBus` implementation in this module treats an empty filter list as "no filtering — deliver everything," which this also broke for a group processor with no handlers wired up yet (`StreamFilter()` returning `[]string{}`).
- Leave `opts.Filter` unset when `filteredEvents` is empty, matching the sibling conventions.

Fixes #46

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass
- [x] Added `TestWithFilterEvents_EmptySliceMeansCatchAll` (adapted from the issue's repro — pure unit test, no live server needed). Verified it actually catches the bug: reverted the fix, confirmed the regex `^()$` doesn't match any real event type exactly as the issue describes, then restored the fix and confirmed it passes