### PR TITLE
Fix MemoryStore.Close not idempotent and Save-after-Close panicking

### DIFF
--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"sync"
@@ -20,6 +21,7 @@ var _ eventsourcing.EventStore = (*MemoryStore)(nil)
 type MemoryStore struct {
 	tracer trace.Tracer
 	mu     sync.RWMutex
+	closed bool
 	bus    chan *eventsourcing.Envelope
 	global []*eventsourcing.Envelope
 	events map[string][]*eventsourcing.Envelope
@@ -83,6 +85,10 @@ func (m *MemoryStore) LoadFromAll(ctx context.Context, version eventsourcing.Str
 func (m *MemoryStore) Save(ctx context.Context, events []eventsourcing.Envelope, revision eventsourcing.StreamState) (eventsourcing.AppendResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.closed {
+		return eventsourcing.AppendResult{Successful: false}, errors.New("save events: event store is closed")
+	}
 
 	if len(events) == 0 {
 		return eventsourcing.AppendResult{Successful: true, NextExpectedVersion: 0}, nil
@@ -228,14 +234,17 @@ func (m *MemoryStore) Events() <-chan *eventsourcing.Envelope {
 }
 
 // Close discards all stored events and closes the channel returned by
-// Events. After Close, the MemoryStore must not be used again.
-//
-// TODO: this is not idempotent, contrary to the eventsourcing.EventStore
-// contract, which asks implementations to make Close safe to call more than
-// once — a second call panics with "close of closed channel" (confirmed).
+// Events. After Close, Save returns an error instead of appending. Calling
+// Close more than once is a no-op.
 func (m *MemoryStore) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+
+	if m.closed {
+		return nil
+	}
+	m.closed = true
+
 	m.events = make(map[string][]*eventsourcing.Envelope)
 	close(m.bus)
 	return nil

--- a/eventstore/memory/eventstore_test.go
+++ b/eventstore/memory/eventstore_test.go
@@ -642,3 +642,50 @@ func TestConcurrent_SaveAndLoad(t *testing.T) {
 	<-done
 	<-done
 }
+
+// TestClose_CalledTwice_Panics is a regression test for GitHub issue #48:
+// Close unconditionally called close(m.bus), so calling it a second time
+// panicked with "close of closed channel", contrary to the EventStore
+// contract that Close must be idempotent.
+func TestClose_CalledTwice_Panics(t *testing.T) {
+	store := memory.NewMemoryStore(10)
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("first Close: unexpected error: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("second Close panicked: %v (EventStore godoc requires Close to be idempotent)", r)
+		}
+	}()
+
+	if err := store.Close(); err != nil {
+		t.Errorf("second Close: unexpected error: %v", err)
+	}
+}
+
+// TestSave_AfterClose_Panics is a regression test for GitHub issue #48:
+// Save's non-blocking send to m.bus only guarded against a full channel,
+// not a closed one, so any Save call after Close panicked with "send on
+// closed channel" instead of returning an error.
+func TestSave_AfterClose_Panics(t *testing.T) {
+	store := memory.NewMemoryStore(10)
+
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close: unexpected error: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Save after Close panicked: %v", r)
+		}
+	}()
+
+	_, err := store.Save(context.Background(), []cqrs.Envelope{
+		{StreamID: "order-1", Event: nil},
+	}, cqrs.Any{})
+	if err == nil {
+		t.Error("expected an error saving to a closed store, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
- `Close` unconditionally called `close(m.bus)`, so calling it a second time panicked with "close of closed channel".
- `Save`'s non-blocking send to `m.bus` only guarded against a full channel, not a closed one, so any `Save` call after `Close` panicked with "send on closed channel" instead of returning an error.
- Both contradict the `EventStore` contract that `Close` must be idempotent and the store must not be used afterward.
- Added a `closed` flag guarded by the existing mutex: `Close` sets it and is a no-op on a second call, and `Save` checks it up front and returns an error instead of writing anything (or reaching the send at all) once closed. Same fix already applied to `eventstore/file` (#39).

Fixes #48

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (177)
- [x] Added `TestClose_CalledTwice_Panics` and `TestSave_AfterClose_Panics` (adapted from the issue's repro). Verified both actually catch the bug: reverted the fix, reproduced both panics exactly as the issue describes, then restored the fix and confirmed both pass