### PR TITLE
Fix MemoryStore.LoadFromAll panicking with Any{}

### DIFF
--- a/eventstore/memory/eventstore.go
+++ b/eventstore/memory/eventstore.go
@@ -29,31 +29,36 @@ type MemoryStore struct {
 
 // LoadFromAll returns a lazy iterator over every event ever saved, across all
 // streams, in the order they were appended, starting at the position
-// identified by version. version is expected to be an
-// [eventsourcing.Revision] (or [eventsourcing.NoStream], which behaves like
-// revision 0); it returns a non-nil error if that position is beyond the
-// number of events currently stored.
+// identified by version. An [eventsourcing.Revision] starts at that index
+// (or [eventsourcing.NoStream], which behaves like revision 0); any other
+// [eventsourcing.StreamState], including [eventsourcing.Any], reads from the
+// beginning. It returns a non-nil error if the requested revision is beyond
+// the number of events currently stored.
 func (m *MemoryStore) LoadFromAll(ctx context.Context, version eventsourcing.StreamState) (*eventsourcing.Iterator[*eventsourcing.Envelope], error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	allEvents := m.global // global slice of all events
 
-	if int(version.ToRawInt64()) >= len(allEvents) {
-		return nil, fmt.Errorf(
-			"load stream %q: requested %d but stream has %d: %w",
-			"all", version, len(allEvents), eventsourcing.ErrInvalidRevision,
-		)
+	// Only eventsourcing.Revision (and eventsourcing.NoStream, treated as
+	// revision 0) carry a meaningful numeric offset; every other
+	// StreamState, including Any{}, means "from the beginning" — matching
+	// LoadStreamFrom's own default: case. Computing an offset from
+	// version.ToRawInt64() unconditionally previously misread Any{}'s -1
+	// (and StreamExists{}'s -2) as a huge uint64 offset.
+	var offset uint64
+	switch v := version.(type) {
+	case eventsourcing.NoStream:
+		// Behaves like revision 0.
+	case eventsourcing.Revision:
+		if int(v.ToRawInt64()) >= len(allEvents) {
+			return nil, fmt.Errorf(
+				"load stream %q: requested %d but stream has %d: %w",
+				"all", v, len(allEvents), eventsourcing.ErrInvalidRevision,
+			)
+		}
+		offset = uint64(v.ToRawInt64())
+	default:
 	}
-
-	// TODO: unlike LoadStreamFrom, this does not type-switch on version, so
-	// eventsourcing.Any.ToRawInt64() (-1) and eventsourcing.StreamExists.ToRawInt64()
-	// (-2) are cast directly to uint64 below, producing a huge offset that
-	// indexes allEvents out of range and panics instead of returning an
-	// error (confirmed: LoadFromAll(ctx, eventsourcing.Any{}) panics with
-	// "index out of range" on the first Next() call, even against an empty
-	// store). Only eventsourcing.Revision and eventsourcing.NoStream (0)
-	// currently work correctly.
-	var offset = uint64(version.ToRawInt64())
 
 	iter := eventsourcing.NewIteratorFunc(func(ctx context.Context) (*eventsourcing.Envelope, error) {
 		if ctx.Err() != nil {

--- a/eventstore/memory/eventstore_test.go
+++ b/eventstore/memory/eventstore_test.go
@@ -689,3 +689,48 @@ func TestSave_AfterClose_Panics(t *testing.T) {
 		t.Error("expected an error saving to a closed store, got nil")
 	}
 }
+
+// TestLoadFromAll_Any is a regression test for GitHub issue #49:
+// LoadFromAll never switched on the concrete type of version, feeding
+// version.ToRawInt64() straight into an unsigned offset. Any{}'s
+// ToRawInt64() of -1 became a huge uint64 offset, panicking with
+// "index out of range" on the very first Next() call — even against an
+// empty store.
+func TestLoadFromAll_Any(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("empty store", func(t *testing.T) {
+		store := memory.NewMemoryStore(10)
+
+		iter, err := store.LoadFromAll(ctx, cqrs.Any{})
+		if err != nil {
+			t.Fatalf("LoadFromAll(Any{}) on an empty store: unexpected error: %v", err)
+		}
+
+		got := collectAll(t, iter)
+		if len(got) != 0 {
+			t.Fatalf("expected 0 events, got %d", len(got))
+		}
+	})
+
+	t.Run("store with events", func(t *testing.T) {
+		store := memory.NewMemoryStore(10)
+
+		if _, err := store.Save(ctx, []cqrs.Envelope{
+			newEnvelope("order-1", OrderCreated{OrderID: "order-1", CustomerID: "cust-1"}),
+			newEnvelope("order-1", ItemAdded{OrderID: "order-1", ItemID: "item-1", Qty: 2}),
+		}, cqrs.NoStream{}); err != nil {
+			t.Fatalf("setup save: %v", err)
+		}
+
+		iter, err := store.LoadFromAll(ctx, cqrs.Any{})
+		if err != nil {
+			t.Fatalf("LoadFromAll(Any{}): unexpected error: %v", err)
+		}
+
+		got := collectAll(t, iter)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 events, got %d", len(got))
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- `LoadFromAll` never switched on the concrete type of `version`, feeding `version.ToRawInt64()` straight into an unsigned offset. `Any{}`'s `ToRawInt64()` of `-1` became a huge `uint64` offset (`StreamExists{}`'s `-2` the same way), and the "past the end?" guard's own int/uint64 round-trip masked it, so `allEvents[offset]` panicked with "index out of range" on the very first `Next()` call — even against an empty store, and regardless of how many events were stored.
- Add the same type switch `LoadStreamFrom` already uses: only `Revision` (and `NoStream`, treated as revision 0) compute a numeric offset; every other `StreamState`, including `Any{}`, starts from the beginning.

Fixes #49

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (179)
- [x] Added `TestLoadFromAll_Any` (adapted from the issue's repro, 2 subtests: empty store and store with events). Verified it actually catches the bug: reverted the fix, reproduced the exact "index out of range [18446744073709551615]" panic, then restored the fix and confirmed both subtests pass