### PR TITLE
Fix QueryBus/QueryGateway data races on unsynchronized map access

### DIFF
--- a/query_bus.go
+++ b/query_bus.go
@@ -88,6 +88,9 @@ func RegisterQueryHandler[T Query, R any](bus *QueryBus, handler QueryHandler[T,
 // handlers are wired up, to catch a missing registration before it can
 // surface as a runtime error.
 func (q *QueryBus) Validate() error {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
 	errs := make([]error, 0)
 	for requestee := range q.requestees {
 		if _, ok := q.handlers[requestee]; !ok {
@@ -99,4 +102,22 @@ func (q *QueryBus) Validate() error {
 		return errors.Join(errs...)
 	}
 	return nil
+}
+
+// addRequestee registers key as a requestee under bus.mu, so it is safe to
+// call concurrently with itself, [RegisterQueryHandler], and [QueryBus.Validate].
+func (q *QueryBus) addRequestee(key string) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.requestees[key] = struct{}{}
+}
+
+// handlerFor returns the handler registered for key, and reports whether one
+// exists. The lock is held only for the map lookup, never for the handler
+// call, so a slow handler cannot block RegisterQueryHandler.
+func (q *QueryBus) handlerFor(key string) (any, bool) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+	h, ok := q.handlers[key]
+	return h, ok
 }

--- a/query_bus_race_test.go
+++ b/query_bus_race_test.go
@@ -1,0 +1,159 @@
+package eventsourcing
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// Query types used only by these tests. Each RegisterQueryHandler call writes a
+// new key into bus.handlers under bus.mu; the gateway closure, NewQueryGateway,
+// and Validate must all honor the same lock.
+type raceQryA struct{ ID_ string }
+
+func (q raceQryA) ID() []byte { return []byte(q.ID_) }
+
+type raceQryB struct{ ID_ string }
+
+func (q raceQryB) ID() []byte { return []byte(q.ID_) }
+
+type raceQryC struct{ ID_ string }
+
+func (q raceQryC) ID() []byte { return []byte(q.ID_) }
+
+type raceQryD struct{ ID_ string }
+
+func (q raceQryD) ID() []byte { return []byte(q.ID_) }
+
+type raceQryE struct{ ID_ string }
+
+func (q raceQryE) ID() []byte { return []byte(q.ID_) }
+
+// Concrete pointer result type, deliberately NOT an interface, so these tests
+// stay independent of the separately filed interface-result key collision.
+type raceQryResult struct{ Value int }
+
+// TestQueryBus_GatewayCallWhileRegistering is a regression test for GitHub
+// issue #52: invoking a QueryGateway while another handler is registered on
+// the same bus raced the gateway closure's unlocked read of bus.handlers
+// against RegisterQueryHandler's locked write.
+func TestQueryBus_GatewayCallWhileRegistering(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		bus := NewQueryBus()
+
+		RegisterQueryHandlerFunc(bus, func(ctx context.Context, q raceQryA) (*raceQryResult, error) {
+			return &raceQryResult{Value: 1}, nil
+		})
+
+		gateway := NewQueryGateway[raceQryA, *raceQryResult](bus)
+
+		// Keep the gateway busy reading bus.handlers, and signal once it is
+		// actually serving so the registrations below overlap it.
+		var wg sync.WaitGroup
+		running := make(chan struct{})
+		stop := make(chan struct{})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var once sync.Once
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if _, err := gateway(context.Background(), raceQryA{ID_: "a"}); err != nil {
+					return
+				}
+				once.Do(func() { close(running) })
+			}
+		}()
+
+		<-running
+
+		// Concurrently register further handlers, each writing bus.handlers.
+		RegisterQueryHandlerFunc(bus, func(ctx context.Context, q raceQryB) (*raceQryResult, error) {
+			return &raceQryResult{Value: 2}, nil
+		})
+		RegisterQueryHandlerFunc(bus, func(ctx context.Context, q raceQryC) (*raceQryResult, error) {
+			return &raceQryResult{Value: 3}, nil
+		})
+		RegisterQueryHandlerFunc(bus, func(ctx context.Context, q raceQryD) (*raceQryResult, error) {
+			return &raceQryResult{Value: 4}, nil
+		})
+		RegisterQueryHandlerFunc(bus, func(ctx context.Context, q raceQryE) (*raceQryResult, error) {
+			return &raceQryResult{Value: 5}, nil
+		})
+
+		close(stop)
+		wg.Wait()
+	}
+}
+
+// TestQueryBus_NewQueryGatewayConcurrent is a regression test for GitHub
+// issue #52: NewQueryGateway wrote bus.requestees with no lock at all, so two
+// goroutines constructing gateways concurrently (e.g. wiring up multiple
+// gateways at startup) performed an unsynchronized concurrent map write.
+func TestQueryBus_NewQueryGatewayConcurrent(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		bus := NewQueryBus()
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = NewQueryGateway[raceQryA, *raceQryResult](bus)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			_ = NewQueryGateway[raceQryB, *raceQryResult](bus)
+		}()
+
+		close(start)
+		wg.Wait()
+	}
+}
+
+// TestQueryBus_ValidateWhileRegistering is a regression test for GitHub issue
+// #52: Validate ranged over q.requestees and read q.handlers without taking
+// q.mu, while RegisterQueryHandler writes q.handlers under q.mu.
+func TestQueryBus_ValidateWhileRegistering(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		bus := NewQueryBus()
+		_ = NewQueryGateway[raceQryA, *raceQryResult](bus)
+
+		var wg sync.WaitGroup
+		running := make(chan struct{})
+		stop := make(chan struct{})
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var once sync.Once
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				_ = bus.Validate()
+				once.Do(func() { close(running) })
+			}
+		}()
+
+		<-running
+
+		RegisterQueryHandlerFunc(bus, func(ctx context.Context, q raceQryA) (*raceQryResult, error) {
+			return &raceQryResult{Value: 1}, nil
+		})
+		RegisterQueryHandlerFunc(bus, func(ctx context.Context, q raceQryB) (*raceQryResult, error) {
+			return &raceQryResult{Value: 2}, nil
+		})
+
+		close(stop)
+		wg.Wait()
+	}
+}

--- a/query_gateway.go
+++ b/query_gateway.go
@@ -38,10 +38,10 @@ type GenericQueryGateway[T Query, R any] = QueryGateway[T, R]
 func NewQueryGateway[T Query, R any](bus *QueryBus) QueryGateway[T, R] {
 	var zero T
 	key := fmt.Sprintf("%T|%T", zero, *new(R))
-	bus.requestees[key] = struct{}{}
+	bus.addRequestee(key)
 
 	return func(ctx context.Context, qry T) (R, error) {
-		h, ok := bus.handlers[key]
+		h, ok := bus.handlerFor(key)
 		if !ok {
 			var zero R
 			return zero, fmt.Errorf("no handler registered for query %T -> %T %w", qry, *new(R), ErrHandlerNotFound)


### PR DESCRIPTION
## Summary
- `RegisterQueryHandler` was the only accessor of `bus.handlers`/`bus.requestees` that took `bus.mu`. `NewQueryGateway` wrote `bus.requestees` with no lock at all, the gateway closure it returns read `bus.handlers` with no lock at all, and `Validate` ranged over `bus.requestees` and read `bus.handlers` the same way. Concurrent use with `RegisterQueryHandler`, or two gateways being built concurrently, raced - the latter case crashes outright with `fatal error: concurrent map writes`.
- Routed every access through the existing `bus.mu` via two new helpers, `addRequestee` and `handlerFor`, matching the locked-lookup pattern already used by `CommandBus.handlerFor`.

Fixes #52

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass (180)
- [x] Added `TestQueryBus_GatewayCallWhileRegistering`, `TestQueryBus_NewQueryGatewayConcurrent`, `TestQueryBus_ValidateWhileRegistering` adapted from the issue's repro. Verified they actually catch the bug: reverted the fix, confirmed a `fatal error: concurrent map writes` crash, then restored the fix and confirmed all pass under `-race`